### PR TITLE
Add rosparam for screenshotting

### DIFF
--- a/launch/all.launch
+++ b/launch/all.launch
@@ -10,6 +10,7 @@
     <arg name="gps_file" default="" />
     <arg name="goal_file" default="" />
     <arg name="wind_file" default="" />
+    <arg name="screenshot" default="false" />
     <include file="$(find local_pathfinding)/launch/launch_all_mocks.launch">
       <arg name="initial_speedup" value="$(arg initial_speedup)"/>
       <arg name="ais_file" value="$(arg ais_file)"/>
@@ -17,6 +18,7 @@
       <arg name="goal_file" value="$(arg goal_file)"/>
       <arg name="wind_file" value="$(arg wind_file)"/>
       <arg name="obstacle_type" value="$(arg obstacle_type)"/>
+      <arg name="screenshot" value="$(arg screenshot)"/>
     </include>
 
     <node pkg="local_pathfinding" type="main_loop.py" name="main_loop" output="$(arg main_loop_output)"/>

--- a/launch/launch_all_mocks.launch
+++ b/launch/launch_all_mocks.launch
@@ -24,6 +24,10 @@
     <arg name="obstacle_type" default="ellipse" />
     <param name="obstacle_type" type="string" value="$(arg obstacle_type)" />
 
+    <!-- Set if screenshots should be taken or not -->
+    <arg name="screenshot" default="false" />
+    <param name="screenshot" type="bool" value="$(arg screenshot)" />
+
     <node pkg="local_pathfinding" type="MOCK_wind_sensor.py" name="MOCK_wind_sensor" />
     <node pkg="local_pathfinding" type="MOCK_controller_and_boat.py" name="MOCK_controller_and_boat" />
     <node pkg="local_pathfinding" type="MOCK_AIS.py" name="MOCK_AIS" />

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -97,7 +97,10 @@ def takeScreenshot():
 
     # Save screenshot
     timeString = datetime.now().strftime('%H-%M-%S')
-    myScreenshot.save("{}/{}.png".format(takeScreenshot.imagePath, timeString))
+    fullImagePath = "{}/{}.png".format(takeScreenshot.imagePath, timeString)
+    rospy.loginfo("Taking screenshot...")
+    myScreenshot.save(fullImagePath)
+    rospy.loginfo("Screenshot saved to {}".format(fullImagePath))
 
 def latlonToXY(latlon, referenceLatlon):
     x = distance((referenceLatlon.lat, referenceLatlon.lon), (referenceLatlon.lat, latlon.lon)).kilometers
@@ -212,8 +215,10 @@ def createLocalPathSS(state, runtimeSeconds=1.0, numRuns=2, plot=False, resetSpe
     if plot:
         plotPathfindingProblem(globalWindDirectionDegrees, dimensions, start, goal, obstacles, state.headingDegrees, amountShrinked)
 
-    # Uncomment to take screenshot of pathfinding setup
-    # takeScreenshot()
+    # Take screenshot
+    shouldTakeScreenshot = rospy.get_param('screenshot', False)
+    if shouldTakeScreenshot:
+        takeScreenshot()
 
     def isValidSolution(solution, referenceLatlon, state):
         if not solution.haveExactSolutionPath():


### PR DESCRIPTION
The purpose of this PR is to add roslaunch arguments to set a rosparameter for screenshotting. The screenshots are taken every time `createLocalPathSS` is called. They are saved to local-pathfinding/images/<Date_of_screenshot>/<Time_of_first_image>/<Time_of_image>.png. If local-pathfinding/images/<Date_of_screenshot> or local-pathfinding/images/<Date_of_screenshot>/<Time_of_first_image> is not created yet, it will make it for you.

To run with screenshots: `roslaunch local_pathfinding all.launch initial_speedup:=100 obstacle_type:="wedge" main_loop_output:="screen" screenshot:=true`

To run without screenshots: `roslaunch local_pathfinding all.launch initial_speedup:=100 obstacle_type:="wedge" main_loop_output:="screen" screenshot:=false` or `To run with screenshots: `roslaunch local_pathfinding all.launch initial_speedup:=100 obstacle_type:="wedge" main_loop_output:="screen"` (default is false).

