### PR TITLE
When request local path update if new path better, need to check that…

### DIFF
--- a/python/main_loop.py
+++ b/python/main_loop.py
@@ -38,7 +38,7 @@ def speedupCallback(data):
     speedup = data.data
 
 
-def updateToNewLocalPath(state, maxAllowableRuntimeSeconds):
+def createNewLocalPath(state, maxAllowableRuntimeSeconds):
     # Composition of functions used every time when updating local path
     global speedup
     localPath = utils.createPath(state, resetSpeedupDuringPlan=True, speedupBeforePlan=speedup,
@@ -74,7 +74,7 @@ if __name__ == '__main__':
 
     # Create first path and track time of updates
     state = sailbot.getCurrentState()
-    localPath, lastTimePathCreated = updateToNewLocalPath(state, utils.MAX_ALLOWABLE_PATHFINDING_TOTAL_RUNTIME_SECONDS)
+    localPath, lastTimePathCreated = createNewLocalPath(state, utils.MAX_ALLOWABLE_PATHFINDING_TOTAL_RUNTIME_SECONDS)
     sailbot.newGlobalPathReceived = False
 
     while not rospy.is_shutdown():
@@ -119,7 +119,7 @@ if __name__ == '__main__':
 
             # Update local path
             state = sailbot.getCurrentState()
-            localPath, lastTimePathCreated = updateToNewLocalPath(
+            localPath, lastTimePathCreated = createNewLocalPath(
                 state, utils.MAX_ALLOWABLE_PATHFINDING_TOTAL_RUNTIME_SECONDS / 2.0)
 
         else:
@@ -144,14 +144,18 @@ if __name__ == '__main__':
                 if isLocalWaypointReached:
                     localPath.removePastWaypoints(state)
 
-                # Update local path if new one is better than old
-                _localPath, _lastTimePathCreated = updateToNewLocalPath(
+                # Create new local path to compare
+                _localPath, _lastTimePathCreated = createNewLocalPath(
                     state, utils.MAX_ALLOWABLE_PATHFINDING_TOTAL_RUNTIME_SECONDS)
                 lastTimePathCreated = _lastTimePathCreated
+
+                # Update local path if new one is better than old AND it reaches the goal
                 currentPathCost = localPath.getCost()
                 newPathCost = _localPath.getCost()
-                rospy.loginfo("currentPathCost = {}. newPathCost = {}".format(currentPathCost, newPathCost))
-                if newPathCost < currentPathCost:
+                newPathReachesGoal = _localPath.reachesGoalLatlon(state.globalWaypoint)
+                rospy.loginfo("currentPathCost = {}. newPathCost = {}. newPathReachesGoal = {}."
+                              .format(currentPathCost, newPathCost, newPathReachesGoal))
+                if newPathCost < currentPathCost and newPathReachesGoal:
                     rospy.loginfo("Updating to new local path")
                     localPath = _localPath
                 else:


### PR DESCRIPTION
… path is valid before performing the cost comparison


The purpose of this PR is to fix a small bug when we generate a new local path to compare to the current path. It currently just checks if the new path has a lower cost. However, sometimes the generated path will not reach the goal, and just be a super short path that goes nowhere. This path will have a very low cost, so it will be selected, but it is completely invalid, so the current path should be kept.