### PR TITLE
Not turn at start

### DIFF
--- a/python/Path.py
+++ b/python/Path.py
@@ -762,8 +762,8 @@ def createPath(state, runtimeSeconds=1.0, numRuns=2, resetSpeedupDuringPlan=Fals
     for i in range(numRuns):
         # TODO: Incorporate globalWindSpeed into pathfinding?
         rospy.loginfo("Starting path-planning run number: {}".format(i))
-        solution = plan(runtimeSeconds, plannerType, 'WeightedLengthAndClearanceCombo',
-                        globalWindDirectionDegrees, dimensions, start, goal, obstacles)
+        solution = plan(runtimeSeconds, plannerType, globalWindDirectionDegrees,
+                        dimensions, start, goal, obstacles, state.headingDegrees)
         if isValidSolution(solution, referenceLatlon, state):
             validSolutions.append(solution)
         else:
@@ -783,8 +783,8 @@ def createPath(state, runtimeSeconds=1.0, numRuns=2, resetSpeedupDuringPlan=Fals
             break
 
         rospy.logwarn("Attempting to rerun with longer runtime: {} seconds".format(runtimeSeconds))
-        solution = plan(runtimeSeconds, "RRTStar", 'WeightedLengthAndClearanceCombo',
-                        globalWindDirectionDegrees, dimensions, start, goal, obstacles)
+        solution = plan(runtimeSeconds, plannerType, globalWindDirectionDegrees,
+                        dimensions, start, goal, obstacles, state.headingDegrees)
 
         if isValidSolution(solution, referenceLatlon, state):
             validSolutions.append(solution)

--- a/python/updated_geometric_planner.py
+++ b/python/updated_geometric_planner.py
@@ -121,7 +121,8 @@ def indexOfObstacleOnPath(positionXY, nextLocalWaypointIndex, numLookAheadWaypoi
     return -1
 
 
-def plan(run_time, planner_type, wind_direction_degrees, dimensions, start_pos, goal_pos, obstacles, heading_degrees, objective_type='WeightedLengthAndClearanceCombo'):
+def plan(run_time, planner_type, wind_direction_degrees, dimensions, start_pos, goal_pos, obstacles, heading_degrees,
+         objective_type='WeightedLengthAndClearanceCombo'):
     # Construct the robot state space in which we're planning
     space = ob.SE2StateSpace()
 

--- a/python/updated_geometric_planner.py
+++ b/python/updated_geometric_planner.py
@@ -121,7 +121,7 @@ def indexOfObstacleOnPath(positionXY, nextLocalWaypointIndex, numLookAheadWaypoi
     return -1
 
 
-def plan(run_time, planner_type, objective_type, wind_direction_degrees, dimensions, start_pos, goal_pos, obstacles):
+def plan(run_time, planner_type, wind_direction_degrees, dimensions, start_pos, goal_pos, obstacles, heading_degrees, objective_type='WeightedLengthAndClearanceCombo'):
     # Construct the robot state space in which we're planning
     space = ob.SE2StateSpace()
 
@@ -161,11 +161,8 @@ def plan(run_time, planner_type, objective_type, wind_direction_degrees, dimensi
     # Set the start and goal states
     ss.setStartAndGoalStates(start, goal)
 
-    # Create the optimization objective (helper function is simply a switch statement) and set wind direction
-    objective = ph.allocate_objective(si, objective_type)
-    for i in range(objective.getObjectiveCount()):
-        if isinstance(objective.getObjective(i), ph.WindObjective):
-            objective.getObjective(i).windDirectionDegrees = wind_direction_degrees
+    # Create the optimization objective (helper function is simply a switch statement)
+    objective = ph.allocate_objective(si, objective_type, wind_direction_degrees, heading_degrees)
     ss.setOptimizationObjective(objective)
 
     # Construct the optimal planner (helper function is simply a switch statement)


### PR DESCRIPTION
Before, the pathfinding did not consider the current direction that the boat was heading before planning. Now, it incurs a turning cost from the turn from the original heading.

Could be tested with:

`roslaunch local_pathfinding all.launch initial_speedup:=100`, then `rostopic pub /changeGlobalWind local_pathfinding/globalWind "directionDegrees: 45.0
speedKmph: 1.0"` to test how the system works in bad upwind condition. It should now turn from the current heading less than before.