### PR TITLE
Move msgs to other repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,11 @@ commands:
     description: "Set Up And Build Workspace"
     steps:
       - run: mkdir -p /catkin_ws/src/local_pathfinding
+      - run: mkdir -p /catkin_ws/src/sailbot_msg
       - run: source /opt/ros/melodic/setup.bash && cd /catkin_ws && catkin_make
       - checkout:
           path: /catkin_ws/src/local_pathfinding
+      - run: git checkout https://github.com/UBCSailbot/sailbot-msg.git /catkin_ws/src/sailbot_msg
       - run: source /opt/ros/melodic/setup.bash && cd /catkin_ws && catkin_make
 
   install_and_run_flake8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
       - run: source /opt/ros/melodic/setup.bash && cd /catkin_ws && catkin_make
       - checkout:
           path: /catkin_ws/src/local_pathfinding
-      - run: git checkout https://github.com/UBCSailbot/sailbot-msg.git /catkin_ws/src/sailbot_msg
+      - run: git clone https://github.com/UBCSailbot/sailbot-msg.git /catkin_ws/src/sailbot_msg
       - run: source /opt/ros/melodic/setup.bash && cd /catkin_ws && catkin_make
 
   install_and_run_flake8:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,20 +47,6 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * uncomment the generate_messages entry below
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
-## Generate messages in the 'msg' folder
-add_message_files(
-  FILES
-  AISMsg.msg
-  AISShip.msg
-  GPS.msg
-  heading.msg
-  latlon.msg
-  path.msg
-  windSensor.msg
-  globalWind.msg
-  addBoat.msg
-)
-
 ## Generate services in the 'srv' folder
 # add_service_files(
 #   FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,10 +62,6 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES
-  std_msgs
-)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##

--- a/install/README.md
+++ b/install/README.md
@@ -10,14 +10,16 @@ The installation process consists of installing OMPL with Python bindings, insta
 
 3. Type the commands `mkdir -p catkin_ws/src` `cd catkin_ws` `catkin_make`.
 
-4. Clone the repository in the src folder: `cd src` `git clone https://github.com/UBCSailbot/local-pathfinding.git`. 
+4. Clone this repository in the src folder: `cd src` `git clone https://github.com/UBCSailbot/local-pathfinding.git`. 
 
-5. Go back to catkin_ws and build and source. `cd ..` `catkin_make` `source devel/setup.bash`.
+5. Clone the sailbot-msgs repository in the src folder: `git clone https://github.com/UBCSailbot/sailbot-msg.git`.
+
+6. Go back to catkin_ws and build and source. `cd ..` `catkin_make` `source devel/setup.bash`.
 
 
 ### Installing OMPL
 
-ROS requires Python2, so we will have a custom ompl installation script for this task. This may take 7-12 hours, as the creation of Python bindings takes a very long time. If you encounter errors in this process, try to run the commands in the script individually and identify where you are having difficulties
+ROS requires Python2, so we will have a custom ompl installation script for this task. This may take 7-16 hours, as the creation of Python bindings takes a very long time. If you encounter errors in this process, try to run the commands in the script individually and identify where you are having difficulties
 
 __Setup Option 1 (Recommended): Installation on the host computer__
 

--- a/msg/AISMsg.msg
+++ b/msg/AISMsg.msg
@@ -1,1 +1,0 @@
-AISShip[] ships

--- a/msg/AISShip.msg
+++ b/msg/AISShip.msg
@@ -1,5 +1,0 @@
-int32 ID
-float64 lat
-float64 lon
-float64 headingDegrees
-float64 speedKmph

--- a/msg/GPS.msg
+++ b/msg/GPS.msg
@@ -1,4 +1,0 @@
-float64 lat
-float64 lon
-float64 headingDegrees
-float64 speedKmph

--- a/msg/addBoat.msg
+++ b/msg/addBoat.msg
@@ -1,3 +1,0 @@
-string addType
-AISShip ship
-int32 waypointIndex

--- a/msg/globalWind.msg
+++ b/msg/globalWind.msg
@@ -1,2 +1,0 @@
-float64 directionDegrees
-float64 speedKmph

--- a/msg/heading.msg
+++ b/msg/heading.msg
@@ -1,1 +1,0 @@
-float64 headingDegrees

--- a/msg/latlon.msg
+++ b/msg/latlon.msg
@@ -1,2 +1,0 @@
-float64 lat
-float64 lon

--- a/msg/path.msg
+++ b/msg/path.msg
@@ -1,1 +1,0 @@
-latlon[] waypoints

--- a/msg/windSensor.msg
+++ b/msg/windSensor.msg
@@ -1,2 +1,0 @@
-float64 measuredDirectionDegrees
-float64 measuredSpeedKmph

--- a/package.xml
+++ b/package.xml
@@ -7,13 +7,13 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="tylerlum@todo.todo">tylerlum</maintainer>
+  <maintainer email="tylergwlum@gmail.com">tylerlum</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/python/MOCK_AIS.py
+++ b/python/MOCK_AIS.py
@@ -8,7 +8,7 @@ from geopy.distance import distance
 from utilities import headingToBearingDegrees, PORT_RENFREW_LATLON
 from std_msgs.msg import Int32
 
-from local_pathfinding.msg import AISShip, AISMsg, GPS
+from sailbot_msg.msg import AISShip, AISMsg, GPS
 
 # Constants
 AIS_PUBLISH_PERIOD_SECONDS = 0.1  # Keep below 1.0 for smoother boat motion

--- a/python/MOCK_UDP_bridge.py
+++ b/python/MOCK_UDP_bridge.py
@@ -3,7 +3,7 @@
 import rospy
 import socket
 
-import local_pathfinding.msg as msg
+import sailbot_msg.msg as msg
 from utilities import headingToBearingDegrees, measuredWindToGlobalWind
 
 try:

--- a/python/MOCK_controller_and_boat.py
+++ b/python/MOCK_controller_and_boat.py
@@ -4,7 +4,7 @@ import random
 import json
 
 from std_msgs.msg import Float64
-import local_pathfinding.msg as msg
+import sailbot_msg.msg as msg
 import geopy.distance
 from utilities import headingToBearingDegrees, PORT_RENFREW_LATLON
 

--- a/python/MOCK_global_planner.py
+++ b/python/MOCK_global_planner.py
@@ -5,7 +5,7 @@ import time
 from utilities import MAUI_LATLON
 
 from std_msgs.msg import Float64
-import local_pathfinding.msg as msg
+import sailbot_msg.msg as msg
 from geopy.distance import distance
 
 # Constants for this class

--- a/python/MOCK_wind_sensor.py
+++ b/python/MOCK_wind_sensor.py
@@ -3,7 +3,7 @@ import rospy
 import json
 
 from std_msgs.msg import Float64
-from local_pathfinding.msg import windSensor, GPS, globalWind
+from sailbot_msg.msg import windSensor, GPS, globalWind
 from utilities import globalWindToMeasuredWind
 import random
 

--- a/python/Path.py
+++ b/python/Path.py
@@ -6,7 +6,7 @@ from updated_geometric_planner import indexOfObstacleOnPath
 import planner_helpers as ph
 import utilities as utils
 import obstacles as obs
-from local_pathfinding.msg import latlon
+from sailbot_msg.msg import latlon
 from geopy.distance import distance
 import matplotlib.pyplot as plt
 from matplotlib import patches
@@ -33,7 +33,7 @@ class OMPLPath:
                                                      used to generate the path.
         _solutionPath (ompl.geometric._geometric.PathGeometric): PathGeometric object that represents the path, in XY
                                                                  coordinates with respect to a referenceLatlon.
-        _referenceLatlon (local_pathfinding.msg._latlon.latlon): latlon object that is the reference point with which
+        _referenceLatlon (sailbot_msg.msg._latlon.latlon): latlon object that is the reference point with which
                                                                  the path's XY coordinates is set.
     """
 
@@ -324,7 +324,7 @@ class Path:
         '''Checks if the given path reaches the given goalLatlon
 
         Args:
-           goalLatlon (local_pathfinding.msg._latlon.latlon): Latlon that this path should be ending at
+           goalLatlon (sailbot_msg.msg._latlon.latlon): Latlon that this path should be ending at
 
         Returns:
            bool True iff the distance between the goalLatlon and the last path waypoint is below a threshold
@@ -358,7 +358,7 @@ class Path:
                 |B
 
         Args:
-           positionLatlon (local_pathfinding.msg._latlon.latlon): Latlon of the current boat position
+           positionLatlon (sailbot_msg.msg._latlon.latlon): Latlon of the current boat position
 
         Returns:
            bool True iff the positionLatlon has reached the next waypoint

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import rospy
-from local_pathfinding.msg import AISMsg, GPS, path, latlon, windSensor
+from sailbot_msg.msg import AISMsg, GPS, path, latlon, windSensor
 from geopy.distance import distance
 
 

--- a/python/addBoat.py
+++ b/python/addBoat.py
@@ -2,7 +2,7 @@
 import rospy
 import math
 import utilities as util
-from local_pathfinding.msg import AISShip, latlon, addBoat, GPS, path, AISMsg
+from sailbot_msg.msg import AISShip, latlon, addBoat, GPS, path, AISMsg
 
 # Globals for callbacks
 localWaypoint = latlon()

--- a/python/collision_checker.py
+++ b/python/collision_checker.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 import rospy
 import utilities
-from local_pathfinding.msg import AISMsg, GPS
+from sailbot_msg.msg import AISMsg, GPS
 from geopy.distance import distance
 from MOCK_AIS import AIS_PUBLISH_PERIOD_SECONDS
 

--- a/python/handleInvalidState.py
+++ b/python/handleInvalidState.py
@@ -3,7 +3,7 @@
 import rospy
 import math
 import planner_helpers as ph
-import local_pathfinding.msg as msg
+import sailbot_msg.msg as msg
 import obstacles as obs
 import utilities as utils
 

--- a/python/json_dumper.py
+++ b/python/json_dumper.py
@@ -3,7 +3,7 @@ import rospy
 import json
 import time
 import datetime
-from local_pathfinding.msg import AISMsg, GPS
+from sailbot_msg.msg import AISMsg, GPS
 global ais_dumped
 global gps_dumped
 

--- a/python/local_path_visualizer.py
+++ b/python/local_path_visualizer.py
@@ -3,7 +3,7 @@ import sys
 import rospy
 import math
 from std_msgs.msg import Float64
-from local_pathfinding.msg import path, latlon
+from sailbot_msg.msg import path, latlon
 import utilities as utils
 import obstacles as obs
 import Sailbot as sbot

--- a/python/main_loop.py
+++ b/python/main_loop.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
-import local_pathfinding.msg as msg
+import sailbot_msg.msg as msg
 import handleInvalidState as his
 from std_msgs.msg import Float64, String, Bool
 import Sailbot as sbot

--- a/python/obstacles.py
+++ b/python/obstacles.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import utilities as utils
 from matplotlib import patches
-from local_pathfinding.msg import latlon
+from sailbot_msg.msg import latlon
 from geopy.distance import distance
 import rospy
 
@@ -26,7 +26,7 @@ def getObstacles(state, referenceLatlon):
 
     Args:
        state (BoatState): State of the sailbot
-       referenceLatlon (local_pathfinding.msg._latlon.latlon): Position of the reference point that will be at (0,0)
+       referenceLatlon (sailbot_msg.msg._latlon.latlon): Position of the reference point that will be at (0,0)
 
     Returns:
        list of obstacles that implement the obstacle interface
@@ -280,9 +280,9 @@ def getProjectedPosition(aisShip, sailbotPosition, sailbotSpeedKmph, referenceLa
 
     Args:
        aisShip (AISShip): State of the ais ship
-       sailbotPosition (local_pathfinding.msg._latlon.latlon): Position of sailbot
+       sailbotPosition (sailbot_msg.msg._latlon.latlon): Position of sailbot
        sailbotSpeedKmph (float): Speed of sailbot in kmph
-       referenceLatlon (local_pathfinding.msg._latlon.latlon): Position of the reference point that will be at (0,0)
+       referenceLatlon (sailbot_msg.msg._latlon.latlon): Position of the reference point that will be at (0,0)
 
     Returns:
        [x, y] projected position of the ais ship

--- a/python/path_storer.py
+++ b/python/path_storer.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 import rospy
 import os
-import local_pathfinding.msg as msg
+import sailbot_msg.msg as msg
 from std_msgs.msg import String, Float64
 from datetime import datetime
 from datetime import date

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -8,7 +8,7 @@ import sys
 import math
 from geopy.distance import distance
 from std_msgs.msg import Float64
-from local_pathfinding.msg import latlon
+from sailbot_msg.msg import latlon
 
 # Location constants
 PORT_RENFREW_LATLON = latlon(48.5, -124.8)
@@ -95,8 +95,8 @@ def latlonToXY(latlon, referenceLatlon):
     '''Calculate the xy (km) coordinates of the given latlon, given the referenceLatlon located at (0,0)
 
     Args:
-       latlon (local_pathfinding.msg._latlon.latlon): The latlon whose xy coordinates will be calculated.
-       referenceLatlon (local_pathfinding.msg._latlon.latlon): The latlon that will be located at (0,0).
+       latlon (sailbot_msg.msg._latlon.latlon): The latlon whose xy coordinates will be calculated.
+       referenceLatlon (sailbot_msg.msg._latlon.latlon): The latlon that will be located at (0,0).
 
     Returns:
        list [x,y] representing the position of latlon in xy (km) coordinates
@@ -115,10 +115,10 @@ def XYToLatlon(xy, referenceLatlon):
 
     Args:
        xy (list of two floats): The xy (km) coordinates whose latlon coordinates will be calculated.
-       referenceLatlon (local_pathfinding.msg._latlon.latlon): The latlon that will be located at (0,0) wrt xy.
+       referenceLatlon (sailbot_msg.msg._latlon.latlon): The latlon that will be located at (0,0) wrt xy.
 
     Returns:
-       local_pathfinding.msg._latlon.latlon representing the position of xy in latlon coordinates
+       sailbot_msg.msg._latlon.latlon representing the position of xy in latlon coordinates
     '''
     x_distance = distance(kilometers=xy[0])
     y_distance = distance(kilometers=xy[1])
@@ -131,8 +131,8 @@ def globalWaypointReached(position, globalWaypoint):
     '''Checks if the position has reached the global waypoint.
 
     Args:
-       position (local_pathfinding.msg._latlon.latlon): Latlon of the position
-       globalWaypoint (local_pathfinding.msg._latlon.latlon): Latlon of the globalWaypoint
+       position (sailbot_msg.msg._latlon.latlon): Latlon of the position
+       globalWaypoint (sailbot_msg.msg._latlon.latlon): Latlon of the globalWaypoint
 
     Returns:
        bool True iff the distance between the position and globalWaypoint is below a threshold
@@ -170,8 +170,8 @@ def getDesiredHeadingDegrees(position, localWaypoint):
     '''Calculate the heading that the boat should aim towards to reach the local waypoint.
 
     Args:
-       position (local_pathfinding.msg._latlon.latlon): Current position of the boat
-       localWaypoint (local_pathfinding.msg._latlon.latlon): Current local waypoint that the boat is aiming towards
+       position (sailbot_msg.msg._latlon.latlon): Current position of the boat
+       localWaypoint (sailbot_msg.msg._latlon.latlon): Current local waypoint that the boat is aiming towards
 
     Returns:
        float that is the heading (degrees) that the boat should be aiming towards to reach the local waypoint
@@ -256,10 +256,10 @@ def headingToBearingDegrees(headingDegrees):
 
     Args:
        xy (list of two floats): The xy (km) coordinates whose latlon coordinates will be calculated.
-       referenceLatlon (local_pathfinding.msg._latlon.latlon): The latlon that will be located at (0,0) wrt xy.
+       referenceLatlon (sailbot_msg.msg._latlon.latlon): The latlon that will be located at (0,0) wrt xy.
 
     Returns:
-       local_pathfinding.msg._latlon.latlon representing the position of xy in latlon coordinates
+       sailbot_msg.msg._latlon.latlon representing the position of xy in latlon coordinates
     '''
     return -headingDegrees + 90
 

--- a/test/test_Path.py
+++ b/test/test_Path.py
@@ -4,7 +4,7 @@ import local_imports  # Must be first import, as it adds python directory to pat
 from geopy.distance import distance
 import utilities as utils
 import Sailbot as sbot
-from local_pathfinding.msg import latlon, AISMsg, AISShip
+from sailbot_msg.msg import latlon, AISMsg, AISShip
 from planner_helpers import UPWIND_MAX_ANGLE_DEGREES, DOWNWIND_MAX_ANGLE_DEGREES
 from Path import createPath, UPWIND_DOWNWIND_TIME_LIMIT_SECONDS
 from updated_geometric_planner import indexOfObstacleOnPath

--- a/test/test_obstacles.py
+++ b/test/test_obstacles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import local_imports  # Must be first import, as it adds python directory to path
-from local_pathfinding.msg import latlon, AISMsg, AISShip
+from sailbot_msg.msg import latlon, AISMsg, AISShip
 import utilities as utils
 import obstacles as obs
 import Sailbot as sbot

--- a/test/test_sailbot.py
+++ b/test/test_sailbot.py
@@ -2,7 +2,7 @@
 
 import local_imports  # Must be first import, as it adds python directory to path
 import Sailbot as sbot
-import local_pathfinding.msg as msg
+import sailbot_msg.msg as msg
 import rospy
 import rostest
 import unittest

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -3,7 +3,7 @@
 import local_imports  # Must be first import, as it adds python directory to path
 from geopy.distance import distance
 import utilities as utils
-from local_pathfinding.msg import latlon
+from sailbot_msg.msg import latlon
 import rostest
 import unittest
 


### PR DESCRIPTION
The purpose of this pull request is to remove the `msg` folder and replace the use of `local_pathfinding.msg` with `sailbot_msg.msg`. It also updates the installation instructions to include the cloning of the `sailbot-msg` repository to still get this working. It also needs to update circleci to clone the sailbot-msg repository to add this dependency.

Addresses #119 and #149 

NOTE: To test this, please `cd` to your `catkin_ws/src` (should be able to see local_pathfinding when you write `ls`). Then `git clone https://github.com/UBCSailbot/sailbot-msg.git`. This adds in the msg files. THEN `cd ..` (so you'll be in `catkin_ws`) `catkin_make` `source devel/setup.bash`.

Then you can test with the usual `roslaunch local_pathfinding all.launch`

