### PR TITLE
Add smooth changes in heading and speed

### DIFF
--- a/launch/all.launch
+++ b/launch/all.launch
@@ -17,6 +17,7 @@
     <arg name="plot_pathfinding_problem" default="false" />
     <arg name="random_seed" default="" />
     <arg name="planner_type" default="RRTStar" />
+    <arg name="smooth_changes" default="true" />
     <include file="$(find local_pathfinding)/launch/launch_all_mocks.launch">
       <arg name="initial_speedup" value="$(arg initial_speedup)"/>
       <arg name="num_ais_ships" value="$(arg num_ais_ships)"/>
@@ -29,6 +30,7 @@
       <arg name="plot_pathfinding_problem" value="$(arg plot_pathfinding_problem)"/>
       <arg name="random_seed" value="$(arg random_seed)" />
       <arg name="planner_type" value="$(arg planner_type)" />
+      <arg name="smooth_changes" value="$(arg smooth_changes)" />
     </include>
 
     <node pkg="local_pathfinding" type="main_loop.py" name="main_loop" output="$(arg main_loop_output)"/>

--- a/launch/launch_all_mocks.launch
+++ b/launch/launch_all_mocks.launch
@@ -44,6 +44,10 @@
     <arg name="planner_type" default="RRTStar" />
     <param name="planner_type" type="string" value="$(arg planner_type)" />
 
+    <!-- Sets if changes in heading and speed should be smooth or not -->
+    <arg name="smooth_changes" default="true" />
+    <param name="smooth_changes" type="bool" value="$(arg smooth_changes)" />
+
     <node pkg="local_pathfinding" type="MOCK_wind_sensor.py" name="MOCK_wind_sensor" />
     <node pkg="local_pathfinding" type="MOCK_controller_and_boat.py" name="MOCK_controller_and_boat" />
     <node pkg="local_pathfinding" type="MOCK_AIS.py" name="MOCK_AIS" />

--- a/python/MOCK_controller_and_boat.py
+++ b/python/MOCK_controller_and_boat.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import rospy
-import random
 import json
 
 from std_msgs.msg import Float64

--- a/python/MOCK_controller_and_boat.py
+++ b/python/MOCK_controller_and_boat.py
@@ -14,9 +14,6 @@ BOAT_SPEED_KMPH = 14.4  # Boat should move at about 4m/s = 14.4 km/h
 TURNING_GAIN = 0.25  # Proportional term in the heading controller
 SPEED_CHANGE_GAIN = 0.05  # The same, but for the speed
 
-# Bring this value to about 1.0 for limited deviation. 20.0 for quite large deviations.
-HEADING_DEGREES_STANDARD_DEVIATION = 1.0
-
 
 class MOCK_ControllerAndSailbot:
     def __init__(self, lat, lon, headingDegrees, speedKmph):

--- a/python/Path.py
+++ b/python/Path.py
@@ -16,7 +16,7 @@ from ompl import geometric as og
 from std_msgs.msg import Float64
 
 # Constants
-UPWIND_DOWNWIND_TIME_LIMIT_SECONDS = 0.5
+UPWIND_DOWNWIND_TIME_LIMIT_SECONDS = 2.0
 MAX_ALLOWABLE_DISTANCE_FINAL_WAYPOINT_TO_GOAL_KM = 5
 
 # Pathfinding constants

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -340,3 +340,13 @@ def setInitialSpeedup():
     rospy.loginfo("Publishing initial_speedup = {}".format(initial_speedup))
     speedupPublisher.publish(initial_speedup)
     time.sleep(1)
+
+
+# Smallest signed angle (degrees)
+def ssa_deg(angle):
+    return ((angle + 180) % 360) - 180
+
+# Smallest signed angle (radians)
+def ssa_rad(angle):
+    return ((angle + math.pi) % 2*math.pi) - math.pi
+

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -331,8 +331,3 @@ def setInitialSpeedup():
 # Smallest signed angle (degrees)
 def ssa_deg(angle):
     return ((angle + 180) % 360) - 180
-
-# Smallest signed angle (radians)
-def ssa_rad(angle):
-    return ((angle + math.pi) % 2*math.pi) - math.pi
-


### PR DESCRIPTION
Fixes https://github.com/UBCSailbot/local-pathfinding/issues/144, replaces https://github.com/UBCSailbot/local-pathfinding/pull/155 (draft).

This PR introduces smooth changes in heading and speed using two P(I)-style controllers. The speed is reduced when turning more than 45 degrees. The maximum reduction factor is 3, for turns larger than or equal to 135 degrees.

Side effect: The speed will nearly drop to zero (but rise again) when the boat is in an invalid start state (with a trailing ship, for example) due to the planner sending lots of desiredHeading messages.