### PR TITLE
Fix speedup bug, so it doesn't wait if no speedup value is set

### DIFF
--- a/python/utilities.py
+++ b/python/utilities.py
@@ -323,6 +323,10 @@ def setInitialSpeedup():
     initial_speedup = rospy.get_param('initial_speedup', default=1.0)
     speedupPublisher = rospy.Publisher('speedup', Float64, queue_size=4)
 
+    # If initial speedup is about 1.0, don't need to do anything here
+    if abs(initial_speedup - 1.0) < 0.1:
+        return
+
     # Wait for other nodes before publishing
     numConnections = speedupPublisher.get_num_connections()
     while numConnections < MIN_NUM_SPEEDUP_SUBS_BEFORE_PUBLISHING:


### PR DESCRIPTION
This ensures that if we run `rosrun local_pathfinding main_loop.py`, then it won't wait for MOCK nodes to be setup for speedup publishing.