### PR TITLE
Use sailbot_msg for messages, not local_pathfinding

### DIFF
--- a/python/log_closest_obstacle.py
+++ b/python/log_closest_obstacle.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import rospy
 from geopy.distance import distance
-from local_pathfinding.msg import AISMsg, GPS
+from sailbot_msg.msg import AISMsg, GPS
 import os
 from datetime import datetime
 from datetime import date


### PR DESCRIPTION
Fixes the following error on launch:
```
Traceback (most recent call last):
  File "/root/catkin_ws/src/local-pathfinding/python/log_closest_obstacle.py", line 4, in <module>
    from local_pathfinding.msg import AISMsg, GPS
ImportError: No module named local_pathfinding.msg
[closest_obstacle-13] process has died [pid 3373, exit code 1, cmd /root/catkin_ws/src/local-pathfinding/python/log_closest_obstacle.py __name:=closest_obstacle __log:=/root/.ros/log/89be38ec-35f2-11eb-b73f-0242ac110002/closest_obstacle-13.log].
log file: /root/.ros/log/89be38ec-35f2-11eb-b73f-0242ac110002/closest_obstacle-13*.log
```