### PR TITLE
Missing and stale data

### DIFF
--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -7,6 +7,19 @@ import sys
 
 
 class BoatState:
+    """Datatype representing the current state of the sailbot, which includes all information relevant for pathfinding.
+
+    Attributes:
+        position (sailbot_msg.msg._latlon.latlon): latlon that is the current latlon position of the boat
+        measuredWindDirectionDegrees (float): measured direction that the wind is going towards wrt the boat
+                                              (0 degrees = going to right of boat, 90 degrees = going to front of boat)
+        measuredWindSpeedKmph (float): measured speed of the wind wrt to boat
+        AISData (sailbot_msg.msg._AISMsg.AISMsg): AIS message with information about nearby boats
+        headingDegrees (float): direction that the boat is heading towards
+                                (0 degrees = going east, 90 degrees = going north)
+        speedKmph (float): speed that the boat is moving
+        globalWaypoint (sailbot_msg.msg._latlon.latlon): global waypoint latlon that the sailbot should be going towards
+    """
     def __init__(self, globalWaypoint, position, measuredWindDirectionDegrees, measuredWindSpeedKmph, AISData,
                  headingDegrees, speedKmph):
         self.globalWaypoint = globalWaypoint
@@ -31,111 +44,30 @@ class BoatState:
 
 
 class Sailbot:
-    def getCurrentState(self):
-        self.printWarningsIfStaleData()
-        if self.globalPathIndex >= len(self.globalPath):
-            rospy.logwarn("Global path index is out of range: index = {} len(globalPath) = {}"
-                          .format(self.globalPathIndex, len(self.globalPath)))
-            rospy.logwarn("Setting globalWaypoint to be the last element of the globalPath")
-            self.globalPathIndex = len(self.globalPath) - 1
-        return BoatState(self.globalPath[self.globalPathIndex], self.position, self.measuredWindDirectionDegrees,
-                         self.measuredWindSpeedKmph, self.AISData, self.headingDegrees, self.speedKmph)
+    """Class for storing, updating, and maintaining the state of the sailbot.
 
-    def GPSCallback(self, data):
-        self.position = latlon(data.lat, data.lon)
-        self.headingDegrees = data.headingDegrees
-        self.speedKmph = data.speedKmph
-        self.GPSLastUpdate = time.time()
+    Attributes:
+        position (sailbot_msg.msg._latlon.latlon): latlon that is the current latlon position of the boat
+        measuredWindDirectionDegrees (float): measured direction that the wind is going towards wrt the boat
+                                              (0 degrees = going to right of boat, 90 degrees = going to front of boat)
+        measuredWindSpeedKmph (float): measured speed of the wind wrt to boat
+        AISData (sailbot_msg.msg._AISMsg.AISMsg): AIS message with information about nearby boats
+        headingDegrees (float): direction that the boat is heading towards
+                                (0 degrees = going east, 90 degrees = going north)
+        speedKmph (float): speed that the boat is moving
+        globalPath (sailbot_msg.msg._latlon.latlon[]): global path list of latlon waypoints that sailbot should follow
 
-    def windSensorCallback(self, data):
-        self.measuredWindDirectionDegrees = data.measuredDirectionDegrees
-        self.measuredWindSpeedKmph = data.measuredSpeedKmph
-        self.windSensorLastUpdate = time.time()
+        GPSLastUpdate (float): time.time() when the GPS was last updated
+        windSensorLastUpdate (float): time.time() when the wind sensor was last updated
+        AISLastUpdate (float): time.time() when the AIS was last updated
+        globalPathLastUpdate (float): time.time() when the global path was last updated
 
-    def AISCallback(self, data):
-        self.AISData = data
-        self.AISLastUpdate = time.time()
-
-    def globalPathCallback(self, data):
-        # Check that new path is valid
-        isValidNewPath = (data.waypoints is not None and len(data.waypoints) >= 2)
-        if not isValidNewPath:
-            rospy.logwarn("Invalid global path received.")
-            return
-
-        # Update if current path is different from new path
-        if self.isNewPath(self.globalPath, data.waypoints):
-            self.updateGlobalPath(data)
-        else:
-            rospy.logwarn_once("New global path is the same as the current path. This warning will only show once")
-            # rospy.logwarn("New global path is the same as the current path.")
-
-        self.globalPathLastUpdate = time.time()
-
-    def isNewPath(self, oldPath, newPath):
-        # Check if they are obviously different
-        if oldPath is None or not len(oldPath) == len(newPath):
-            return True
-
-        # Path is different if there exists a point with distance >1km away from current point
-        MAX_DISTANCE_BETWEEN_SAME_POINTS_KM = 1
-        for i in range(len(oldPath)):
-            oldFirstPoint = (oldPath[i].lat, oldPath[i].lon)
-            newFirstPoint = (newPath[i].lat, newPath[i].lon)
-            if distance(oldFirstPoint, newFirstPoint).kilometers > MAX_DISTANCE_BETWEEN_SAME_POINTS_KM:
-                return True
-
-        return False
-
-    def updateGlobalPath(self, data):
-        rospy.loginfo("New global path received.")
-        self.newGlobalPathReceived = True
-        self.globalPath = data.waypoints
-        self.globalPathIndex = 1  # First waypoint is the start point, so second waypoint is the next global waypoint
-
-    def printWarningsIfStaleData(self):
-        current_time = time.time()
-        GPSStaleLimitSeconds = 60
-        windSensorStaleLimitSeconds = 60
-        AISStaleLimitSeconds = 60
-        globalPathStaleLimitSeconds = 60 * 60 * 24 * 2
-        if current_time - self.GPSLastUpdate > GPSStaleLimitSeconds:
-            rospy.logwarn("GPS stale. Not updated for {} seconds ({} limit)"
-                          .format(current_time - self.GPSLastUpdate, GPSStaleLimitSeconds))
-        if current_time - self.windSensorLastUpdate > windSensorStaleLimitSeconds:
-            rospy.logwarn("windSensor stale. Not updated for {} seconds ({} limit)"
-                          .format(current_time - self.windSensorLastUpdate, windSensorStaleLimitSeconds))
-        if current_time - self.AISLastUpdate > AISStaleLimitSeconds:
-            rospy.logwarn("AIS stale. Not updated for {} seconds ({} limit)"
-                          .format(current_time - self.AISLastUpdate, AISStaleLimitSeconds))
-        if current_time - self.globalPathLastUpdate > globalPathStaleLimitSeconds:
-            rospy.logwarn("globalPath stale. Not updated for {} seconds ({} limit)"
-                          .format(current_time - self.globalPathLastUpdate, globalPathStaleLimitSeconds))
-
-    def waitForFirstSensorDataAndGlobalPath(self):
-        def isMissingFirstSensorDataOrGlobalPath():
-            return (self.position is None or self.measuredWindDirectionDegrees is None or
-                    self.measuredWindSpeedKmph is None or self.AISData is None or
-                    self.headingDegrees is None or self.speedKmph is None or self.globalPath is None)
-
-        while isMissingFirstSensorDataOrGlobalPath():
-            # Exit if shutdown
-            if rospy.is_shutdown():
-                rospy.loginfo("rospy.is_shutdown() is True. Exiting")
-                sys.exit()
-            else:
-                rospy.loginfo("Waiting for sailbot to receive first sensor data and global path")
-                rospy.loginfo("self.position is None? {}. self.measuredWindDirectionDegrees is None? {}. "
-                              "self.measuredWindSpeedKmph is None? {}. self.AISData is None? {}. "
-                              "self.headingDegrees is None? {}. self.speedKmph is None? {}. "
-                              "self.globalPath is None? {}."
-                              .format(self.position is None, self.measuredWindDirectionDegrees is None,
-                                      self.measuredWindSpeedKmph is None, self.AISData is None,
-                                      self.headingDegrees is None, self.speedKmph is None, self.globalPath is None))
-                time.sleep(1)
-
-        rospy.loginfo("First sensor data and global path received")
-
+        globalPathIndex (int): index of the global path waypoint (in globalPath) that the sailbot should be going
+                               towards. As of right now, has to be updated manually from outside of Sailbot when reached
+                               TODO: Could make this able to be updated internally, not need to modify from outside
+        newGlobalPathReceived (bool): defaults false. True when a new global path has been received. Can be modified
+                                      from outside of Sailbot when newly received global path has been processed
+    """
     def __init__(self, nodeName):
         # Sensor data and global path
         self.position = None
@@ -161,6 +93,148 @@ class Sailbot:
         rospy.Subscriber("windSensor", windSensor, self.windSensorCallback)
         rospy.Subscriber("AIS", AISMsg, self.AISCallback)
         rospy.Subscriber("globalPath", path, self.globalPathCallback)
+
+    def getCurrentState(self):
+        '''Get the current sailbot boatstate, which includes all information relevant for pathfinding.
+
+        Notes:
+        * Should only be run after running waitForFirstSensorDataAndGlobalPath() to ensure valid data
+        * Prints warnings if there is stale data.
+        * If sailbot reaches end of its global path so that its globalPathIndex >= len(globalPath), then it
+          simply sets the next global waypoint to be the last global waypoint
+
+        Returns:
+           BoatState representing the current state of the sailbot
+        '''
+        if self.isMissingFirstSensorDataOrGlobalPath():
+            rospy.logerr("Can't get current state: missing first sensor data or global path")
+            return None
+
+        # Print warnings about stale data
+        self.printWarningsIfStaleData()
+
+        # End of global path edge case
+        if self.globalPathIndex >= len(self.globalPath):
+            rospy.logwarn("Global path index is out of range: index = {} len(globalPath) = {}"
+                          .format(self.globalPathIndex, len(self.globalPath)))
+            rospy.logwarn("Setting globalWaypoint to be the last element of the globalPath")
+            self.globalPathIndex = len(self.globalPath) - 1
+
+        return BoatState(self.globalPath[self.globalPathIndex], self.position, self.measuredWindDirectionDegrees,
+                         self.measuredWindSpeedKmph, self.AISData, self.headingDegrees, self.speedKmph)
+
+    def GPSCallback(self, data):
+        self.position = latlon(data.lat, data.lon)
+        self.headingDegrees = data.headingDegrees
+        self.speedKmph = data.speedKmph
+        self.GPSLastUpdate = time.time()
+
+    def windSensorCallback(self, data):
+        self.measuredWindDirectionDegrees = data.measuredDirectionDegrees
+        self.measuredWindSpeedKmph = data.measuredSpeedKmph
+        self.windSensorLastUpdate = time.time()
+
+    def AISCallback(self, data):
+        self.AISData = data
+        self.AISLastUpdate = time.time()
+
+    def globalPathCallback(self, data):
+        '''Updates the global path if:
+
+        * The new path is valid (has length >= 2)
+        * The new path is different from the old path
+
+        Assumes that global path is setup so that waypoint index 0 is close to the current position and
+        waypoint index 1 is the next global waypoint.
+        Sets newGlobalPathReceived to True so that external systems can check when a new global path has been received
+        '''
+        def isNewPath(oldPath, newPath):
+            # Check if they are obviously different
+            if oldPath is None or not len(oldPath) == len(newPath):
+                return True
+
+            # Path is different if there exists a point with distance >1km away from current point
+            MAX_DISTANCE_BETWEEN_SAME_POINTS_KM = 1
+            for i in range(len(oldPath)):
+                oldFirstPoint = (oldPath[i].lat, oldPath[i].lon)
+                newFirstPoint = (newPath[i].lat, newPath[i].lon)
+                if distance(oldFirstPoint, newFirstPoint).kilometers > MAX_DISTANCE_BETWEEN_SAME_POINTS_KM:
+                    return True
+
+            return False
+
+        # Check that new path is valid
+        isValidNewPath = (data.waypoints is not None and len(data.waypoints) >= 2)
+        if not isValidNewPath:
+            rospy.logwarn("Invalid global path received.")
+            return
+
+        # Update if current path is different from new path
+        if isNewPath(self.globalPath, data.waypoints):
+            rospy.loginfo("New global path received.")
+            self.newGlobalPathReceived = True
+            self.globalPath = data.waypoints
+            self.globalPathIndex = 1  # First waypoint is start point, so second waypoint is next global waypoint
+        else:
+            rospy.logwarn_once("New global path is the same as the current path. This warning will only show once")
+            # rospy.logwarn("New global path is the same as the current path.")
+
+        self.globalPathLastUpdate = time.time()
+
+    def printWarningsIfStaleData(self):
+        """Prints warning messages if there is stale data (subscribers haven't received new messages)"""
+        # Edge case check to avoid null pointer errors
+        if self.isMissingFirstSensorDataOrGlobalPath():
+            rospy.logwarn("Can't print warnings about stale data: missing first sensor data or global path")
+            return
+
+        current_time = time.time()
+        GPSStaleLimitSeconds = 60
+        windSensorStaleLimitSeconds = 60
+        AISStaleLimitSeconds = 60
+        globalPathStaleLimitSeconds = 60 * 60 * 24 * 2
+        if current_time - self.GPSLastUpdate > GPSStaleLimitSeconds:
+            rospy.logwarn("GPS stale. Not updated for {} seconds ({} limit)"
+                          .format(current_time - self.GPSLastUpdate, GPSStaleLimitSeconds))
+        if current_time - self.windSensorLastUpdate > windSensorStaleLimitSeconds:
+            rospy.logwarn("windSensor stale. Not updated for {} seconds ({} limit)"
+                          .format(current_time - self.windSensorLastUpdate, windSensorStaleLimitSeconds))
+        if current_time - self.AISLastUpdate > AISStaleLimitSeconds:
+            rospy.logwarn("AIS stale. Not updated for {} seconds ({} limit)"
+                          .format(current_time - self.AISLastUpdate, AISStaleLimitSeconds))
+        if current_time - self.globalPathLastUpdate > globalPathStaleLimitSeconds:
+            rospy.logwarn("globalPath stale. Not updated for {} seconds ({} limit)"
+                          .format(current_time - self.globalPathLastUpdate, globalPathStaleLimitSeconds))
+
+    def waitForFirstSensorDataAndGlobalPath(self):
+        """Waits until first sensor data and global path have been received by subscribers"""
+        while self.isMissingFirstSensorDataOrGlobalPath():
+            # Exit if shutdown
+            if rospy.is_shutdown():
+                rospy.loginfo("rospy.is_shutdown() is True. Exiting")
+                sys.exit()
+            else:
+                rospy.loginfo("Waiting for sailbot to receive first sensor data and global path")
+                rospy.loginfo("self.position is None? {}. self.measuredWindDirectionDegrees is None? {}. "
+                              "self.measuredWindSpeedKmph is None? {}. self.AISData is None? {}. "
+                              "self.headingDegrees is None? {}. self.speedKmph is None? {}. "
+                              "self.globalPath is None? {}."
+                              .format(self.position is None, self.measuredWindDirectionDegrees is None,
+                                      self.measuredWindSpeedKmph is None, self.AISData is None,
+                                      self.headingDegrees is None, self.speedKmph is None, self.globalPath is None))
+                time.sleep(1)
+
+        rospy.loginfo("First sensor data and global path received")
+
+    def isMissingFirstSensorDataOrGlobalPath(self):
+        """Checks if the subscribers have all received their first messages
+
+        Returns:
+           bool True iff the subscribers have all received their first messages
+        """
+        return (self.position is None or self.measuredWindDirectionDegrees is None or
+                self.measuredWindSpeedKmph is None or self.AISData is None or
+                self.headingDegrees is None or self.speedKmph is None or self.globalPath is None)
 
 
 # Example code of how this class works.

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -175,9 +175,6 @@ class Sailbot:
             self.newGlobalPathReceived = True
             self.globalPath = data.waypoints
             self.globalPathIndex = 1  # First waypoint is start point, so second waypoint is next global waypoint
-        else:
-            rospy.logwarn_once("New global path is the same as the current path. This warning will only show once")
-            # rospy.logwarn("New global path is the same as the current path.")
 
         self.globalPathLastUpdate = time.time()
 

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -98,13 +98,14 @@ class Sailbot:
         '''Get the current sailbot boatstate, which includes all information relevant for pathfinding.
 
         Notes:
-        * Should only be run after running waitForFirstSensorDataAndGlobalPath() to ensure valid data
+        * Should only be run after running waitForFirstSensorDataAndGlobalPath() to get valid data, else returns None
         * Prints warnings if there is stale data.
         * If sailbot reaches end of its global path so that its globalPathIndex >= len(globalPath), then it
           simply sets the next global waypoint to be the last global waypoint
 
         Returns:
-           BoatState representing the current state of the sailbot
+           BoatState representing the current state of the sailbot.
+           Returns None if first subscriber messages have not been received
         '''
         if self.isMissingFirstSensorDataOrGlobalPath():
             rospy.logerr("Can't get current state: missing first sensor data or global path")

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -166,6 +166,7 @@ class Sailbot:
 # Example code of how this class works.
 if __name__ == '__main__':
     sailbot = Sailbot(nodeName='testSailbot')
+    sailbot.waitForFirstSensorDataAndGlobalPath()
     r = rospy.Rate(1)  # hz
 
     while not rospy.is_shutdown():

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -192,7 +192,7 @@ class Sailbot:
         GPSStaleLimitSeconds = 60
         windSensorStaleLimitSeconds = 60
         AISStaleLimitSeconds = 60
-        globalPathStaleLimitSeconds = 60 * 60 * 24 * 2
+        globalPathStaleLimitSeconds = 60
         if current_time - self.GPSLastUpdate > GPSStaleLimitSeconds:
             rospy.logwarn("GPS stale. Not updated for {} seconds ({} limit)"
                           .format(current_time - self.GPSLastUpdate, GPSStaleLimitSeconds))

--- a/python/local_path_visualizer.py
+++ b/python/local_path_visualizer.py
@@ -117,6 +117,7 @@ if __name__ == '__main__':
         else:
             rospy.loginfo("Waiting to receive first ROS messages")
             time.sleep(1)
+    sailbot.waitForFirstSensorDataAndGlobalPath()
     rospy.loginfo("ROS message received. Starting visualization")
 
     # Convert values from latlon to XY, relative to the referenceLatlon

--- a/python/main_loop.py
+++ b/python/main_loop.py
@@ -84,8 +84,8 @@ if __name__ == '__main__':
     pathCostBreakdownPublisher = rospy.Publisher('localPathCostBreakdown', String, queue_size=4)
     publishRate = rospy.Rate(1.0 / MAIN_LOOP_PERIOD_SECONDS)
 
-    # Wait until first global path is received
-    utils.waitForGlobalPath(sailbot)
+    # Wait until first sensor data + globalPath is received
+    sailbot.waitForFirstSensorDataAndGlobalPath()
 
     # Set the initial speedup value. Best done here in main_loop to ensure the timing.
     # Should be published before loop begins.

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -4,7 +4,6 @@ from datetime import date
 import os
 import rospy
 import time
-import sys
 import math
 from geopy.distance import distance
 from std_msgs.msg import Float64
@@ -277,23 +276,6 @@ def pathCostThresholdExceeded(path):
     rospy.loginfo("pathCost = {}. Cost threshold for this length = {}"
                   .format(pathCost, costThreshold))
     return pathCost > costThreshold
-
-
-def waitForGlobalPath(sailbot):
-    '''Wait until the sailbot object receives a global path message. Outputs log messages with updates.
-
-    Args:
-       sailbot (Sailbot): Sailbot object with which the checking for global path message will happen.
-    '''
-    while not sailbot.newGlobalPathReceived:
-        # Exit if shutdown
-        if rospy.is_shutdown():
-            rospy.loginfo("rospy.is_shutdown() is True. Exiting")
-            sys.exit()
-        else:
-            rospy.loginfo("Waiting for sailbot to receive first newGlobalPath")
-            time.sleep(1)
-    rospy.loginfo("newGlobalPath received")
 
 
 def setInitialSpeedup():


### PR DESCRIPTION
The purpose of this PR is to handle missing or stale sensor/global path data.

**Problem 1**: The pathfinding should not start until Sailbot.py has received its first GPS, AIS, windSensor, and globalPath message (otherwise, it would be using defaults that are completely arbitrary). 

**Solution 1**: Before starting main_loop, wait to receive first messages. Start all values as None to be very clear.

**Problem 2**: The pathfinding should send obvious warnings when it does not receive data for a certain time. Eg. if it doesn't receive windSensor data for 60 seconds, then we should know that something is wrong.

**Solution 2**: Set a `lastUpdated` member variable for each sensor/global path callback. Each time we getCurrentState of Sailobt, we should get warnings if there is stale data.

To test, don't use roslaunch, but open one node at a time.

```
roscore
```

```
rosrun local_pathfinding main_loop.py
```

Should now display that it is waiting for data.

```
rosrun local_pathfinding MOCK_controller_and_boat.py
```

Display should show that GPS data has been received.

```
rosrun local_pathfinding MOCK_wind_sensor.py
```

```
rosrun local_pathfinding MOCK_global_planner.py
```

```
rosrun local_pathfinding MOCK_AIS.py
```

Now pathfinding should begin.

Run the visualizer to view what's going on:

```
rosrun local_pathfinding local_path_visualizer.py
```

Then close one of the MOCK nodes to simulate a sensor no longer sending data. Should get yellow warning messages after the time limit has been reached (60s right now).



 