### PR TITLE
Handle no solution found by using previous solution

### DIFF
--- a/python/Path.py
+++ b/python/Path.py
@@ -625,6 +625,7 @@ def createPath(state, runtimeSeconds=None, numRuns=None, resetSpeedupDuringPlan=
 
     Returns:
        Path object representing the path from state.position to state.globalWaypoint
+       Returns None if cannot find a single valid solution in the given maxAllowableRuntimeSeconds
     '''
     # Helper methods
     def getXYLimits(start, goal, extraLengthFraction=0.6):
@@ -788,10 +789,10 @@ def createPath(state, runtimeSeconds=None, numRuns=None, resetSpeedupDuringPlan=
 
         # If valid solution can't be found for large runtime, then stop searching
         if totalRuntimeSeconds >= maxAllowableRuntimeSeconds:
-            rospy.logwarn("No valid solution can be found in under {} seconds. Using invalid solution."
-                          .format(maxAllowableRuntimeSeconds))
+            rospy.logerr("No valid solution can be found in under {} seconds. Returning None."
+                         .format(maxAllowableRuntimeSeconds))
             incrementCountInvalidSolutions()
-            break
+            return None
 
         rospy.logwarn("Attempting to rerun with longer runtime: {} seconds".format(runtimeSeconds))
         solution = plan(runtimeSeconds, plannerType, state.globalWindDirectionDegrees,


### PR DESCRIPTION
**DESCRIPTION**
Before: If could not find solution within max allowed time, tried to just use an invalid solution. However, this actually doesn't work. Invalid solutions don't even partly work, and they cause the code to fail.
![image](https://user-images.githubusercontent.com/26510814/125179119-1fd4f880-e1a0-11eb-9101-57e9c3673b5c.png)

After: If can't find solution within max allowed time, revert to previous local path we were using before. On first run with nothing before, give unlimited time.
![image](https://user-images.githubusercontent.com/26510814/125179112-16e42700-e1a0-11eb-97e7-fe75df017a79.png)

**REPRODUCE ERROR**
On master branch, first go to `python/Path.py` and `change`
```
MAX_ALLOWABLE_PATHFINDING_TOTAL_RUNTIME_SECONDS = 20.0
```
to 0.1 (give very little time to run).

Then run this
```
roslaunch local_pathfinding all.launch num_ais_ships:=50 random_seed:=4100 runtime_seconds:=0.001 num_runs:=1 speedup:=200
```

**TEST FIX**
Repeat steps above on this branch.

It will find a solution for the first run (has unlimited time for first try). Every future one will run out of time, but simply revert to old solution instead of dying. Not that elegant, but what else can you do other than going into infinite loops...