### PR TITLE
Add Noise to GPS and Wind sensors

### DIFF
--- a/launch/all.launch
+++ b/launch/all.launch
@@ -37,6 +37,7 @@
     <arg name="random_seed" default="" />
     <arg name="start_lat" default="" />
     <arg name="start_lon" default="" />
+    <arg name="sensor_noise" default="false" />
     <arg name="goal_lat" default="" />
     <arg name="goal_lon" default="" />
     <arg name="ais_file" default="" />
@@ -55,6 +56,7 @@
       <arg name="random_seed" value="$(arg random_seed)" />
       <arg name="start_lat" value="$(arg start_lat)" />
       <arg name="start_lon" value="$(arg start_lon)" />
+      <arg name="sensor_noise" value="$(arg sensor_noise)" />
       <arg name="goal_lat" value="$(arg goal_lat)" />
       <arg name="goal_lon" value="$(arg goal_lon)" />
       <arg name="ais_file" value="$(arg ais_file)"/>

--- a/launch/launch_all_mocks.launch
+++ b/launch/launch_all_mocks.launch
@@ -35,6 +35,10 @@
     <param name="goal_lat" type="string" value="$(arg goal_lat)" />
     <param name="goal_lon" type="string" value="$(arg goal_lon)" />
 
+    <!-- Sets sensor_noise -->
+    <arg name="sensor_noise" default="false" />
+    <param name="sensor_noise" value="$(arg sensor_noise)" />
+
     <!-- Sets ais_file, the FULL path of a JSON file to be read to set the initial AIS ship positions, initial sailbot position, goal position, initial wind condition -->
     <arg name="ais_file" default="" />
     <arg name="gps_file" default="" />

--- a/launch/launch_all_mocks.launch
+++ b/launch/launch_all_mocks.launch
@@ -37,7 +37,7 @@
 
     <!-- Sets sensor_noise -->
     <arg name="sensor_noise" default="false" />
-    <param name="sensor_noise" value="$(arg sensor_noise)" />
+    <param name="sensor_noise" type="bool" value="$(arg sensor_noise)" />
 
     <!-- Sets ais_file, the FULL path of a JSON file to be read to set the initial AIS ship positions, initial sailbot position, goal position, initial wind condition -->
     <arg name="ais_file" default="" />

--- a/python/MOCK_sensors.py
+++ b/python/MOCK_sensors.py
@@ -37,16 +37,9 @@ def getStartLatLon(defaultLat, defaultLon):
     return (startLat, startLon)
 
 
-def getSensorNoise():
-    # Read in sensor noise
-    sensorNoise = rospy.get_param('sensor_noise', default=False)
-    sensorNoise = bool(sensorNoise)
-    return sensorNoise
-
-
 class MOCK_SensorManager:
     def __init__(self, startLat, startLon, startHeadingDegrees, startSpeedKmph, startGlobalWindSpeedKmph,
-                 startGlobalWindDirectionDegrees, sensorNoise):
+                 startGlobalWindDirectionDegrees):
         # Initialize starting values
         self.lat = startLat
         self.lon = startLon
@@ -56,7 +49,6 @@ class MOCK_SensorManager:
         self.globalWindDirectionDegrees = startGlobalWindDirectionDegrees
         self.measuredWindSpeedKmph, self.measuredWindDirectionDegrees = globalWindToMeasuredWind(
             self.globalWindSpeedKmph, self.globalWindDirectionDegrees, self.speedKmph, self.headingDegrees)
-        self.sensorNoise = sensorNoise
         self.publishPeriodSeconds = SENSORS_PUBLISH_PERIOD_SECONDS
 
         # Setup ROS node inputs and outputs
@@ -142,7 +134,7 @@ class MOCK_SensorManager:
         # data.gyroscope_y_velocity_millidegreesps
         # data.gyroscope_z_velocity_millidegreesps
 
-        if self.sensorNoise:
+        if rospy.get_param('sensor_noise', default=False):
             data = self.add_noise(data)
         self.publisher.publish(data)
 
@@ -207,13 +199,11 @@ class MOCK_SensorManager:
 
 if __name__ == '__main__':
     startLat, startLon = getStartLatLon(defaultLat=PORT_RENFREW_LATLON.lat, defaultLon=PORT_RENFREW_LATLON.lon)
-    sensorNoise = getSensorNoise()
     sensorManager = MOCK_SensorManager(startLat=startLat, startLon=startLon,
                                        startHeadingDegrees=START_BOAT_HEADING_DEGREES,
                                        startSpeedKmph=START_BOAT_SPEED_KMPH,
                                        startGlobalWindSpeedKmph=START_GLOBAL_WIND_SPEED_KMPH,
-                                       startGlobalWindDirectionDegrees=START_GLOBAL_WIND_DIRECTION_DEGREES,
-                                       sensorNoise=sensorNoise)
+                                       startGlobalWindDirectionDegrees=START_GLOBAL_WIND_DIRECTION_DEGREES)
     r = rospy.Rate(float(1) / SENSORS_PUBLISH_PERIOD_SECONDS)
 
     while not rospy.is_shutdown():

--- a/python/MOCK_sensors.py
+++ b/python/MOCK_sensors.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import numpy as np
 import rospy
 
 import sailbot_msg.msg as msg
@@ -13,6 +14,8 @@ START_BOAT_SPEED_KMPH = 14.4  # Boat should move at about 4m/s = 14.4 km/h
 START_BOAT_HEADING_DEGREES = 180
 START_GLOBAL_WIND_DIRECTION_DEGREES = 0
 START_GLOBAL_WIND_SPEED_KMPH = 10
+STDEV_GPS = 0.00001
+STDEV_WIND = 0.1
 
 
 def getStartLatLon(defaultLat, defaultLon):
@@ -88,33 +91,41 @@ class MOCK_SensorManager:
             self.globalWindSpeedKmph, self.globalWindDirectionDegrees, self.speedKmph, self.headingDegrees)
 
     def publish(self):
+        # add noise here
         # Populate sensors, leaving commented out the ones we don't know for now
         data = msg.Sensors()
 
         # data.sailencoder_degrees
 
-        data.wind_sensor_1_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
-        data.wind_sensor_1_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
-        data.wind_sensor_2_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
-        data.wind_sensor_2_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
-        data.wind_sensor_3_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
-        data.wind_sensor_3_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
+        data.wind_sensor_1_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND, 1)[0]
+        data.wind_sensor_1_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
+                                                            STDEV_WIND, 1)[0]
+        data.wind_sensor_2_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND, 1)[0]
+        data.wind_sensor_2_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
+                                                            STDEV_WIND, 1)[0]
+        data.wind_sensor_3_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND, 1)[0]
+        data.wind_sensor_3_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
+                                                            STDEV_WIND, 1)[0]
 
         # data.gps_can_timestamp_utc
-        data.gps_can_latitude_degrees = self.lat
-        data.gps_can_longitude_degrees = self.lon
-        data.gps_can_groundspeed_knots = self.speedKmph / KNOTS_TO_KMPH
-        data.gps_can_track_made_good_degrees = headingToBearingDegrees(self.headingDegrees)
-        data.gps_can_true_heading_degrees = headingToBearingDegrees(self.headingDegrees)
+        data.gps_can_latitude_degrees = np.random.normal(self.lat, STDEV_GPS, 1)[0]
+        data.gps_can_longitude_degrees = np.random.normal(self.lon, STDEV_GPS, 1)[0]
+        data.gps_can_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS, 1)[0]
+        data.gps_can_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
+                                                                1)[0]
+        data.gps_can_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
+                                                             1)[0]
         # data.gps_can_magnetic_variation_degrees
         # data.gps_can_state
 
         # data.gps_ais_timestamp_utc
-        data.gps_ais_latitude_degrees = self.lat
-        data.gps_ais_longitude_degrees = self.lon
-        data.gps_ais_groundspeed_knots = self.speedKmph / KNOTS_TO_KMPH
-        data.gps_ais_track_made_good_degrees = headingToBearingDegrees(self.headingDegrees)
-        data.gps_ais_true_heading_degrees = headingToBearingDegrees(self.headingDegrees)
+        data.gps_ais_latitude_degrees = np.random.normal(self.lat, STDEV_GPS, 1)[0]
+        data.gps_ais_longitude_degrees = np.random.normal(self.lon, STDEV_GPS, 1)[0]
+        data.gps_ais_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS, 1)[0]
+        data.gps_ais_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
+                                                                1)[0]
+        data.gps_ais_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
+                                                             1)[0]
         # data.gps_ais_magnetic_variation_degrees
         # data.gps_ais_state
 

--- a/python/MOCK_sensors.py
+++ b/python/MOCK_sensors.py
@@ -97,35 +97,31 @@ class MOCK_SensorManager:
 
         # data.sailencoder_degrees
 
-        data.wind_sensor_1_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND, 1)[0]
+        data.wind_sensor_1_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND)
         data.wind_sensor_1_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
-                                                            STDEV_WIND, 1)[0]
-        data.wind_sensor_2_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND, 1)[0]
+                                                            STDEV_WIND)
+        data.wind_sensor_2_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND)
         data.wind_sensor_2_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
-                                                            STDEV_WIND, 1)[0]
-        data.wind_sensor_3_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND, 1)[0]
+                                                            STDEV_WIND)
+        data.wind_sensor_3_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND)
         data.wind_sensor_3_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
-                                                            STDEV_WIND, 1)[0]
+                                                            STDEV_WIND)
 
         # data.gps_can_timestamp_utc
-        data.gps_can_latitude_degrees = np.random.normal(self.lat, STDEV_GPS, 1)[0]
-        data.gps_can_longitude_degrees = np.random.normal(self.lon, STDEV_GPS, 1)[0]
-        data.gps_can_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS, 1)[0]
-        data.gps_can_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
-                                                                1)[0]
-        data.gps_can_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
-                                                             1)[0]
+        data.gps_can_latitude_degrees = np.random.normal(self.lat, STDEV_GPS)
+        data.gps_can_longitude_degrees = np.random.normal(self.lon, STDEV_GPS)
+        data.gps_can_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS)
+        data.gps_can_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
+        data.gps_can_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
         # data.gps_can_magnetic_variation_degrees
         # data.gps_can_state
 
         # data.gps_ais_timestamp_utc
-        data.gps_ais_latitude_degrees = np.random.normal(self.lat, STDEV_GPS, 1)[0]
-        data.gps_ais_longitude_degrees = np.random.normal(self.lon, STDEV_GPS, 1)[0]
-        data.gps_ais_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS, 1)[0]
-        data.gps_ais_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
-                                                                1)[0]
-        data.gps_ais_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS,
-                                                             1)[0]
+        data.gps_ais_latitude_degrees = np.random.normal(self.lat, STDEV_GPS)
+        data.gps_ais_longitude_degrees = np.random.normal(self.lon, STDEV_GPS)
+        data.gps_ais_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS)
+        data.gps_ais_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
+        data.gps_ais_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
         # data.gps_ais_magnetic_variation_degrees
         # data.gps_ais_state
 

--- a/python/MOCK_sensors.py
+++ b/python/MOCK_sensors.py
@@ -91,37 +91,33 @@ class MOCK_SensorManager:
             self.globalWindSpeedKmph, self.globalWindDirectionDegrees, self.speedKmph, self.headingDegrees)
 
     def publish(self):
-        # add noise here
         # Populate sensors, leaving commented out the ones we don't know for now
         data = msg.Sensors()
 
         # data.sailencoder_degrees
 
-        data.wind_sensor_1_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND)
-        data.wind_sensor_1_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
-                                                            STDEV_WIND)
-        data.wind_sensor_2_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND)
-        data.wind_sensor_2_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
-                                                            STDEV_WIND)
-        data.wind_sensor_3_speed_knots = np.random.normal(self.measuredWindSpeedKmph / KNOTS_TO_KMPH, STDEV_WIND)
-        data.wind_sensor_3_angle_degrees = np.random.normal(headingToBearingDegrees(self.measuredWindDirectionDegrees),
-                                                            STDEV_WIND)
+        data.wind_sensor_1_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
+        data.wind_sensor_1_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
+        data.wind_sensor_2_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
+        data.wind_sensor_2_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
+        data.wind_sensor_3_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
+        data.wind_sensor_3_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
 
         # data.gps_can_timestamp_utc
-        data.gps_can_latitude_degrees = np.random.normal(self.lat, STDEV_GPS)
-        data.gps_can_longitude_degrees = np.random.normal(self.lon, STDEV_GPS)
-        data.gps_can_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS)
-        data.gps_can_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
-        data.gps_can_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
+        data.gps_can_latitude_degrees = self.lat
+        data.gps_can_longitude_degrees = self.lon
+        data.gps_can_groundspeed_knots = self.speedKmph / KNOTS_TO_KMPH
+        data.gps_can_track_made_good_degrees = headingToBearingDegrees(self.headingDegrees)
+        data.gps_can_true_heading_degrees = headingToBearingDegrees(self.headingDegrees)
         # data.gps_can_magnetic_variation_degrees
         # data.gps_can_state
 
         # data.gps_ais_timestamp_utc
-        data.gps_ais_latitude_degrees = np.random.normal(self.lat, STDEV_GPS)
-        data.gps_ais_longitude_degrees = np.random.normal(self.lon, STDEV_GPS)
-        data.gps_ais_groundspeed_knots = np.random.normal(self.speedKmph / KNOTS_TO_KMPH, STDEV_GPS)
-        data.gps_ais_track_made_good_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
-        data.gps_ais_true_heading_degrees = np.random.normal(headingToBearingDegrees(self.headingDegrees), STDEV_GPS)
+        data.gps_ais_latitude_degrees = self.lat
+        data.gps_ais_longitude_degrees = self.lon
+        data.gps_ais_groundspeed_knots = self.speedKmph / KNOTS_TO_KMPH
+        data.gps_ais_track_made_good_degrees = headingToBearingDegrees(self.headingDegrees)
+        data.gps_ais_true_heading_degrees = headingToBearingDegrees(self.headingDegrees)
         # data.gps_ais_magnetic_variation_degrees
         # data.gps_ais_state
 
@@ -138,7 +134,54 @@ class MOCK_SensorManager:
         # data.gyroscope_y_velocity_millidegreesps
         # data.gyroscope_z_velocity_millidegreesps
 
-        self.publisher.publish(data)
+        noisy_data = self.add_noise(data)
+        self.publisher.publish(noisy_data)
+
+    def add_noise(self, data):
+        # Add noise to sensor data using numpy.random.normal. GPS and wind sensors have different standard deviations,
+        # with GPS readings being much more accurate and consistent. Unused sensors are commented out.
+        noisy_data = msg.Sensors()
+
+        # data.sailencoder_degrees
+
+        noisy_data.wind_sensor_1_speed_knots = np.random.normal(data.wind_sensor_1_speed_knots, STDEV_WIND)
+        noisy_data.wind_sensor_1_angle_degrees = np.random.normal(data.wind_sensor_1_angle_degrees, STDEV_WIND)
+        noisy_data.wind_sensor_2_speed_knots = np.random.normal(data.wind_sensor_2_speed_knots, STDEV_WIND)
+        noisy_data.wind_sensor_2_angle_degrees = np.random.normal(data.wind_sensor_2_angle_degrees, STDEV_WIND)
+        noisy_data.wind_sensor_3_speed_knots = np.random.normal(data.wind_sensor_3_speed_knots, STDEV_WIND)
+        noisy_data.wind_sensor_3_angle_degrees = np.random.normal(data.wind_sensor_3_angle_degrees, STDEV_WIND)
+
+        # data.gps_can_timestamp_utc
+        noisy_data.gps_can_latitude_degrees = np.random.normal(data.gps_can_latitude_degrees, STDEV_GPS)
+        noisy_data.gps_can_longitude_degrees = np.random.normal(data.gps_can_longitude_degrees, STDEV_GPS)
+        noisy_data.gps_can_groundspeed_knots = np.random.normal(data.gps_can_groundspeed_knots, STDEV_GPS)
+        noisy_data.gps_can_track_made_good_degrees = np.random.normal(data.gps_can_track_made_good_degrees, STDEV_GPS)
+        noisy_data.gps_can_true_heading_degrees = np.random.normal(data.gps_can_true_heading_degrees, STDEV_GPS)
+        # data.gps_can_magnetic_variation_degrees
+        # data.gps_can_state
+
+        noisy_data.gps_ais_latitude_degrees = np.random.normal(data.gps_ais_latitude_degrees, STDEV_GPS)
+        noisy_data.gps_ais_longitude_degrees = np.random.normal(data.gps_ais_longitude_degrees, STDEV_GPS)
+        noisy_data.gps_ais_groundspeed_knots = np.random.normal(data.gps_ais_groundspeed_knots, STDEV_GPS)
+        noisy_data.gps_ais_track_made_good_degrees = np.random.normal(data.gps_ais_track_made_good_degrees, STDEV_GPS)
+        noisy_data.gps_ais_true_heading_degrees = np.random.normal(data.gps_ais_true_heading_degrees, STDEV_GPS)
+        # data.gps_ais_magnetic_variation_degrees
+        # data.gps_ais_state
+
+        # data.winch_main_angle_degrees
+        # data.winch_jib_angle_degrees
+        # data.rudder_port_angle_degrees
+        # data.rudder_stbd_angle_degrees
+
+        # data.accelerometer_x_force_millig
+        # data.accelerometer_y_force_millig
+        # data.accelerometer_z_force_millig
+
+        # data.gyroscope_x_velocity_millidegreesps
+        # data.gyroscope_y_velocity_millidegreesps
+        # data.gyroscope_z_velocity_millidegreesps
+
+        return noisy_data
 
     def desiredHeadingCallback(self, data):
         # rostopic uses North=0, East=90


### PR DESCRIPTION
Draw a random sample from a Gaussian distribution using [numpy.random.normal](https://numpy.org/doc/stable/reference/random/generated/numpy.random.normal.html). GPS sensors have a much lower standard deviation than wind sensors (and wind speed itself varies quite a bit). The aim was for GPS sensors to vary ~10-20m, but further refinement of the standard deviation constants may be necessary.

Add noise to sensors with `sensor_noise:=true` in the roslaunch command.