### PR TITLE
Add wandb option for main_loop_and_interface, and add additional logs

### DIFF
--- a/launch/main_loop_and_interface.launch
+++ b/launch/main_loop_and_interface.launch
@@ -32,6 +32,11 @@
     <arg name="enable_los" default="false" />
     <param name="enable_los" type="bool" value="$(arg enable_los)" />
 
+    <!-- Wandb logger -->
+    <arg name="wandb" default="false" />
+    <node pkg="local_pathfinding" type="wandb_log.py" name="wandb_log" if="$(arg wandb)" output="screen" />
+
+    <!-- Main loop and interface -->
     <node pkg="local_pathfinding" type="main_loop.py" name="main_loop" output="$(arg main_loop_output)"/>
     <node pkg="local_pathfinding" type="ros_interface.py" name="ros_interface" output="$(arg ros_interface_output)"/>
 </launch>

--- a/python/wandb_log.py
+++ b/python/wandb_log.py
@@ -8,15 +8,22 @@ from collision_checker import CollisionChecker
 from store_sailbot_gps import SailbotGPSData
 from utilities import takeScreenshot
 from PIL import Image
+import Sailbot as sbot
 
+# Parameters for what and how to log
 UPDATE_TIME_SECONDS = 1.0
 SCREENSHOT_PERIOD_SECONDS = 10.0
+LATLON_TABLE = False
+SCREENSHOT = False
 
 
 if __name__ == '__main__':
     os.environ["WANDB_SILENT"] = "true"  # Avoid small wandb bug
-    rospy.init_node('wandb_log')
-    wandb.init(entity='ubcsailbot', project='sailbot-test-2')
+    wandb.init(entity='ubcsailbot', project='sailbot-default-project')
+
+    # Subscribe to essential pathfinding info
+    sailbot = sbot.Sailbot(nodeName='wandb_log')
+    sailbot.waitForFirstSensorDataAndGlobalPath()
 
     # Log parameters
     config = wandb.config
@@ -38,6 +45,7 @@ if __name__ == '__main__':
         collision_checker.check_for_collisions()
         collision_checker.check_for_warnings()
         sailbot_gps_data.StoreSailbotGPS()
+        boatState = sailbot.getCurrentState()
 
         # Store logs
         validDataReady = (len(log_closest_obstacle.closestDistances) > 0 and len(path_storer.pathCosts) > 0 and
@@ -50,7 +58,23 @@ if __name__ == '__main__':
                        'Lon': sailbot_gps_data.lon,
                        'DisplacementKm': sailbot_gps_data.Find_Distance(),
                        'ClosestObstacleDistanceKm': log_closest_obstacle.closestDistances[-1],
-                       'PathCost': path_storer.pathCosts[-1]}
+                       'PathCost': path_storer.pathCosts[-1],
+                       'Heading': boatState.headingDegrees,
+                       'Speed': boatState.speedKmph,
+                       'GlobalWindDirection': boatState.globalWindDirectionDegrees,
+                       'GlobalWindSpeedKmph': boatState.globalWindSpeedKmph,
+                      }
+            # Next, previous, and last local waypoint
+            currentPath = path_storer.paths[-1]
+            if len(currentPath) >= 2:
+                nextWaypoint, prevWaypoint, lastWaypoint = currentPath[1], currentPath[0], currentPath[-1],
+                new_log.update({"NextWaypointLat": nextWaypoint.lat,
+                                "NextWaypointLon": nextWaypoint.lon,
+                                "PrevWaypointLat": prevWaypoint.lat,
+                                "PrevWaypointLon": prevWaypoint.lon,
+                                "LastWaypointLat": lastWaypoint.lat,
+                                "LastWaypointLon": lastWaypoint.lon,
+                                })
 
             # Get objective and their weighted cost.
             # Will be in form: [..., 'Weighted', 'cost', '=', '79343.0', ...]
@@ -65,12 +89,13 @@ if __name__ == '__main__':
             wandb.log(new_log)
 
             # Latlon scatter plot
-            data = [[lon, lat] for (lat, lon) in zip(sailbot_gps_data.latArray, sailbot_gps_data.lonArray)]
-            table = wandb.Table(data=data, columns=['Lon', 'Lat'])
-            wandb.log({'LatlonPlot': wandb.plot.scatter(table, 'Lon', 'Lat', title='Sailbot Latlon Plot')})
+            if LATLON_TABLE:
+                data = [[lon, lat] for (lat, lon) in zip(sailbot_gps_data.latArray, sailbot_gps_data.lonArray)]
+                table = wandb.Table(data=data, columns=['Lon', 'Lat'])
+                wandb.log({'LatlonPlot': wandb.plot.scatter(table, 'Lon', 'Lat', title='Sailbot Latlon Plot')})
 
             # Screenshot
-            if counter % (SCREENSHOT_PERIOD_SECONDS // UPDATE_TIME_SECONDS) == 0:
+            if SCREENSHOT and counter % (SCREENSHOT_PERIOD_SECONDS // UPDATE_TIME_SECONDS) == 0:
                 screenshot_path = takeScreenshot(return_path_to_file=True)
                 screenshot = Image.open(screenshot_path)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26510814/136678604-1fb6d733-87da-4684-ba10-5eb089be08e8.png)

Setup for Oct 16 launch. Adds wandb for testing with additional logs and hiding high bandwidth logs.

How to test:

Run main loop with wandb (will run this on big day)
```
roslaunch local_pathfinding main_loop_and_interface.launch wandb:=true
```

MAY NEED TO LOG IN: Follow wandb instructions.

Create mocks:
```
rosrun local_pathfinding MOCK_sensors.py
rosrun local_pathfinding MOCK_AIS.py
rosrun local_pathfinding MOCK_global_planner.py
```

View logs on wandb website
https://wandb.ai/ubcsailbot/sailbot-default-project/runs/kilw2sez?workspace=user-ubcsailbot

Wandb login info on the Slack #pathfinding pinned post.
