### PR TITLE
Change heading degrees topic to desired heading degrees

### DIFF
--- a/python/MOCK_sensors.py
+++ b/python/MOCK_sensors.py
@@ -54,7 +54,7 @@ class MOCK_SensorManager:
         # Setup ROS node inputs and outputs
         rospy.init_node('MOCK_SensorManager', anonymous=True)
         self.publisher = rospy.Publisher("sensors", msg.Sensors, queue_size=4)
-        rospy.Subscriber("heading_degrees", msg.heading, self.desiredHeadingCallback)
+        rospy.Subscriber("desired_heading_degrees", msg.heading, self.desiredHeadingCallback)
 
         # Inputs for testing
         rospy.Subscriber("changeGPS", msg.GPS, self.changeGPSCallback)

--- a/python/main_loop.py
+++ b/python/main_loop.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     rospy.Subscriber('forceLocalPathUpdate', Bool, localPathUpdateForcedCallback)
 
     # Create ros publisher for the desired heading for the controller
-    desiredHeadingPublisher = rospy.Publisher('heading_degrees', msg.heading, queue_size=4)
+    desiredHeadingPublisher = rospy.Publisher('desired_heading_degrees', msg.heading, queue_size=4)
 
     # Create other publishers
     localPathPublisher = rospy.Publisher('localPath', msg.path, queue_size=4)


### PR DESCRIPTION
Change topic name from `heading_degrees` to `desired_heading_degrees` to match with controller and documentation, and improve clarity of this topic's purpose. This is NOT the current heading of the system, but rather the desired heading of the system which is the output of the local pathfinding system.