### PR TITLE
Decrease size and number of boats as obstacles

### DIFF
--- a/python/MOCK_exactAIS.py
+++ b/python/MOCK_exactAIS.py
@@ -37,8 +37,6 @@ class MOCK_AISEnvironment:
         # Create ships
         self.last_real_ship_pull = time.time()  # The timestamp for the last time we downloaded new ship positions
         self.publishPeriodSeconds = AIS_PUBLISH_PERIOD_SECONDS
-
-        self.last_real_ship_pull = time.time()  # The timestamp for the last time we downloaded new ship positions
         self.get_real_ships()
 
     def make_ros_message(self):


### PR DESCRIPTION
BEFORE:
* Way too many boats (607)
* Boats get way too big (>20km)
![image](https://user-images.githubusercontent.com/26510814/136883466-edc8eccf-b832-4119-be02-e7c9b5d4b1fa.png)

AFTER:
* Cap boats at 50 closest
* Cap boat length at 2km
![image](https://user-images.githubusercontent.com/26510814/136883413-86d6893d-864a-43d6-92c8-d3518f898ae0.png)

Test with 
```
roslaunch local_pathfinding all.launch AIS_token:=48c3ccc0-4fcf-4379-833e-8b1d3c409dd7 start_lat:=49.275202 start_lon:=-123.160124 goal_lat:=49.212129  goal_lon:=-123.307560 global_wind_direction_degrees:=0 land_mass_file:=land_masses/vancouver_depth_5m_10_11_2021-10_28_14.csv        
```
(Start new kits, match latlon to our test goal, add land mass). Need to wait for up to 2 min to get AIS data.

Once see all the boats, can run `rosrun local_pathfinding json_dumper.py` to store AIS ships. Then next time run 
```
roslaunch local_pathfinding all.launch start_lat:=49.275202 start_lon:=-123.160124 goal_lat:=49.212129  goal_lon:=-123.307560 global_wind_direction_degrees:=0 land_mass_file:=land_masses/vancouver_depth_5m_10_11_2021-10_28_14.csv ais_file:=`pwd`/ais-19297.json
```
To use stored boats instead of AIS token