### PR TITLE
All /AIS inputs are 0 North, and then converted to 0 East in Sailbot

### DIFF
--- a/python/MOCK_AIS.py
+++ b/python/MOCK_AIS.py
@@ -4,7 +4,7 @@ import random
 import json
 
 from geopy.distance import distance
-from utilities import headingToBearingDegrees, PORT_RENFREW_LATLON, get_rosparam_or_default_if_invalid
+from utilities import PORT_RENFREW_LATLON, get_rosparam_or_default_if_invalid
 from std_msgs.msg import Int32
 
 from sailbot_msg.msg import AISShip, AISMsg, GPS
@@ -44,7 +44,8 @@ def createRandomSimulatedShip(referenceLat, referenceLon, mmsi=None):
 
 
 class Ship:
-    '''Base class for storing ship data'''
+    '''Base class for storing ship data
+    heading is defined as 0 North, 90 East'''
     def __init__(self, MMSI, lat, lon, heading, speed):
         self.id = MMSI
         self.lat = lat
@@ -63,7 +64,7 @@ class SimulatedShip(Ship):
     '''Simulated ship that can be moved over time by the simulation'''
     def move(self, movement_time_seconds):
         distanceTraveledKm = self.speedKmph * movement_time_seconds / 3600
-        bearingOfTravelDegrees = headingToBearingDegrees(self.headingDegrees)
+        bearingOfTravelDegrees = self.headingDegrees
         boatLatlon = distance(kilometers=distanceTraveledKm).destination(point=(self.lat, self.lon),
                                                                          bearing=bearingOfTravelDegrees)
         self.lat = boatLatlon.latitude

--- a/python/MOCK_exactAIS.py
+++ b/python/MOCK_exactAIS.py
@@ -6,7 +6,7 @@ import time
 import datetime
 import os
 
-from utilities import bearingToHeadingDegrees, PORT_RENFREW_LATLON, XYToLatlon
+from utilities import PORT_RENFREW_LATLON, XYToLatlon
 
 from MOCK_AIS import Ship
 from sailbot_msg.msg import AISMsg, GPS, latlon
@@ -89,7 +89,7 @@ class MOCK_AISEnvironment:
             new_ship = RealShip(int(real_ship[u'mmsi']),
                                 float(real_ship[u'latitude']),
                                 float(real_ship[u'longitude']),
-                                bearingToHeadingDegrees(float(real_ship[u'cog'])),
+                                float(real_ship[u'cog']),  # Should be 0 North, 90 East
                                 float(real_ship[u'sog']) * 0.54)
             self.real_ships.append(new_ship)
 
@@ -98,7 +98,7 @@ class MOCK_AISEnvironment:
                     'id': real_ship[u'mmsi'],
                     'lat': real_ship[u'latitude'],
                     'lon': real_ship[u'longitude'],
-                    'headingDegrees': bearingToHeadingDegrees(float(real_ship[u'cog'])),
+                    'headingDegrees': float(real_ship[u'cog']),  # Should be 0 North, 90 East
                     'speedKmph': float(real_ship[u'sog']) * 0.54
                 },
                 'length': real_ship[u'length'],

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -5,6 +5,7 @@ from sailbot_msg.msg import AISMsg, GPS, path, latlon, globalWind
 from geopy.distance import distance
 import time
 import sys
+import utilities as utils
 
 # Global variables for moving waypoint
 goalWasInvalid = False
@@ -146,6 +147,11 @@ class Sailbot:
 
         if goalWasInvalid:
             state.globalWaypoint = movedGlobalWaypoint
+
+        # Expects AISData from /AIS to have heading convention (0 North, 90 East)
+        # Convert AIS bearing (0 North, 90 East) to heading (0 East, 90 North)
+        for ship in state.AISData.ships:
+            ship.headingDegrees = utils.bearingToHeadingDegrees(ship.headingDegrees)
 
         return state
 


### PR DESCRIPTION
Addresses #253 

Can verify with simple:
```
roslaunch local_pathfindng all.launch
```

```
rostopic echo /AIS
```

Check if the heading matches expected. Echo'd value should be in 0 North, 90 East