### PR TITLE
Log filtering logic to wandb

### DIFF
--- a/python/wandb_log.py
+++ b/python/wandb_log.py
@@ -76,7 +76,6 @@ def sensorFilters(sensor_data_dict):
     filtered_values_dict['wind_sensor_std_speed_knots'] = np.std(wind_speeds)
 
     # wind direction filters/stats
-    wind_speeds = [sensor_data_dict[field] for field in WIND_SPEED_FIELDS]
     wind_directions = [sensor_data_dict[field] for field in WIND_DIRECTION_FIELDS]
     average_angle = vectorAverage(np.ones(len(wind_directions)), wind_directions)[1]
     filtered_values_dict['wind_sensor_mean_threshold_angle_degrees'] = average_angle \
@@ -84,7 +83,6 @@ def sensorFilters(sensor_data_dict):
     filtered_values_dict['wind_sensor_std_angle_degrees'] = np.std(wind_directions)
 
     # wind vector average filters
-    wind_speeds = [sensor_data_dict[field] for field in WIND_SPEED_FIELDS]
     vector_speed, vector_angle = vectorAverage(wind_speeds, wind_directions)
     filtered_values_dict['wind_sensor_vector_speed_knots'] = vector_speed
     filtered_values_dict['wind_sensor_vector_threshold_angle_degrees'] = vector_angle \

--- a/python/wandb_log.py
+++ b/python/wandb_log.py
@@ -120,7 +120,7 @@ def vectorAverage(magnitudes, angles):
 
 if __name__ == '__main__':
     os.environ["WANDB_SILENT"] = "true"  # Avoid small wandb bug
-    wandb.init(entity='sailbot', project='sailbot-default-project')
+    wandb.init(entity='sailbot', project='dry-land-testing')
 
     # Subscribe to essential pathfinding info
     sailbot = sbot.Sailbot(nodeName='wandb_log')


### PR DESCRIPTION
Logs a variety of statistics and filtering methods to Wandb so that we can view and compare filters live during dry land testing. See the `windSensorFilters()` docstring for what has been implemented so far, and ideas for more exotic filtering methods. The graphs in [sailbot-default-project](https://wandb.ai/ubcsailbot/sailbot-default-project) have been updated accordingly.

@hhenry01 no need to checkout to this branch if you are only testing 1 wind sensor. Works when all 3 sensors are running, but will need to modify the `WIND_SPEED_FIELDS` and `WIND_DIRECTION_FIELDS` global variables to get it working when 2 sensors are running.

https://github.com/UBCSailbot/local-pathfinding/blob/a62360d57d383a364f611e9cd1cb25b3bf9b328c/python/wandb_log.py#L31-L32

#### Notes
- I arbitrarily chose the value for the `WIND_SPEED_THRESHOLD` global variable, so that can be finetuned
- Idea: time average as a function of wind speed: higher speed -> shorter average
- Consider warning when sensor values are far apart
- Once GPS AIS is working, look into GPS filter options
    - Average
- I created a Wiki page for Wandb, feel free to add to it: https://github.com/UBCSailbot/local-pathfinding/wiki/Wandb

#### Potential Resources
- Kalman filter
    - https://towardsdatascience.com/kalman-filter-an-algorithm-for-making-sense-from-the-insights-of-various-sensors-fused-together-ddf67597f35e
    - https://www.researchgate.net/publication/267705230_Wind_direction_and_speed_forecasting_optimization_algorithm_for_ship_based_on_time_series_and_Kalman_filter
- Moving average, exponentially weighted moving average: https://hackaday.com/2019/09/06/sensor-filters-for-coders/