### PR TITLE
Avoid ZeroDivisionError when global waypoints are the same

### DIFF
--- a/python/handleInvalidState.py
+++ b/python/handleInvalidState.py
@@ -131,8 +131,8 @@ def moveGlobalWaypointUntilValid(state, isLast, otherWaypoint):
         deltaY = goalY - otherY if isLast else otherY - goalY
         dist = math.sqrt(deltaX**2 + deltaY**2)
 
-        goalX += MOVE_GOAL_WAYPOINT_STEP_SIZE_KM * deltaX / dist
-        goalY += MOVE_GOAL_WAYPOINT_STEP_SIZE_KM * deltaY / dist
+        goalX += MOVE_GOAL_WAYPOINT_STEP_SIZE_KM * deltaX / (dist + 1e-8)
+        goalY += MOVE_GOAL_WAYPOINT_STEP_SIZE_KM * deltaY / (dist + 1e-8)
         goalLatlon = utils.XYToLatlon((goalX, goalY), referenceLatlon)
         rospy.logwarn('Moved goalLatlon to ({},{})'.format(goalLatlon.lat, goalLatlon.lon))
 


### PR DESCRIPTION
When the current global waypoint is invalid (eg. has a boat on it), we can't keep going towards that or we will hit something. Thus, we need to move the global waypoint. Which direction do we move the global waypoint? The old way was to move it in the direction of the next global waypoint. But if the current and next global waypoints are the same (distance between waypoints is 0), then we get division by 0. To avoid the unrecoverable error, change `/ dist` to `/ (dist + 1e-8)`.