### PR TITLE
Correct typo in wandb node filename

### DIFF
--- a/launch/main_loop_and_interface.launch
+++ b/launch/main_loop_and_interface.launch
@@ -39,7 +39,7 @@
     <!-- Wandb loggers -->
     <arg name="wandb" default="false" />
     <node pkg="local_pathfinding" type="wandb_log_latlon_plots.py" name="log_latlon_plots" if="$(arg wandb)" output="screen" />
-    <node pkg="local_pathfinding" type="wandb_logs_stats.py" name="log_stats" if="$(arg wandb)" output="screen" />
+    <node pkg="local_pathfinding" type="wandb_log_stats.py" name="log_stats" if="$(arg wandb)" output="screen" />
 
     <!-- Main loop and interface -->
     <node pkg="local_pathfinding" type="main_loop.py" name="main_loop" output="$(arg main_loop_output)"/>


### PR DESCRIPTION
`wand_logs_stats.py` -> `wandb_log_stats.py`