### PR TITLE
Update angle bounding and conventions

### DIFF
--- a/python/MOCK_sensors.py
+++ b/python/MOCK_sensors.py
@@ -5,6 +5,7 @@ import rospy
 import sailbot_msg.msg as msg
 import geopy.distance
 from utilities import (
+    flipDirection,
     headingToBearingDegrees,
     bearingToHeadingDegrees,
     PORT_RENFREW_LATLON,
@@ -84,10 +85,13 @@ class MOCK_SensorManager:
 
         data.wind_sensor_1_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
         data.wind_sensor_1_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
+        data.wind_sensor_1_angle_degrees = flipDirection(data.wind_sensor_1_angle_degrees)
         data.wind_sensor_2_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
         data.wind_sensor_2_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
+        data.wind_sensor_2_angle_degrees = flipDirection(data.wind_sensor_2_angle_degrees)
         data.wind_sensor_3_speed_knots = self.measuredWindSpeedKmph / KNOTS_TO_KMPH
         data.wind_sensor_3_angle_degrees = headingToBearingDegrees(self.measuredWindDirectionDegrees)
+        data.wind_sensor_3_angle_degrees = flipDirection(data.wind_sensor_3_angle_degrees)
 
         # data.gps_can_timestamp_utc
         data.gps_can_latitude_degrees = self.lat

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -360,14 +360,18 @@ def ewma(current_val, past_ewma, weight, is_angle):
         is_angle (bool): True when getting the field is an angle, false otherwise.
 
     Returns:
-        float: The exponentially weighted moving average.
+        float: The exponentially weighted moving average, bounded in [0, 360) if is_angle is true.
     """
     if past_ewma is None:
         return current_val
 
     if is_angle:
         _, current_val = mitsutaVals((past_ewma, current_val))
-    return weight * current_val + (1 - weight) * past_ewma
+
+    ret_val = (weight * current_val) + ((1 - weight) * past_ewma)
+    if is_angle:
+        ret_val %= 360
+    return ret_val
 
 
 def mitsutaVals(angles):

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -302,7 +302,7 @@ def headingToBearingDegrees(headingDegrees):
     Returns:
        float representing the same angle in bearing coordinates
     '''
-    return boundIn0To360(-headingDegrees + 90)
+    return (-headingDegrees + 90) % 360
 
 
 def bearingToHeadingDegrees(bearingDegrees):
@@ -319,19 +319,7 @@ def bearingToHeadingDegrees(bearingDegrees):
     Returns:
        float representing the same angle in heading coordinates
     '''
-    return boundIn0To360(-bearingDegrees + 90)
-
-
-def boundIn0To360(angle):
-    ''' Given an angle in degrees, calculates an equivalent angle bounded in [0, 360)
-
-    Args:
-        angle (float or integer): an angle to be bounded, measured in degrees
-
-    Returns:
-        equivalent angle bounded to [0, 360). The return type matches the type of the input angle.
-    '''
-    return (angle % 360) if (angle >= 0 or angle % 360 == 0) else (360 - (-angle % 360))
+    return (-bearingDegrees + 90) % 360
 
 
 def vectorAverage(magnitudes, angles, weights=None):

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -360,9 +360,9 @@ def ewma(current_val, past_ewma, weight, is_angle):
     Weight is a discrete linear function of current_val.
 
     Args:
-        current_val (float): Current value.
-        past_ewma (float): Past value (EWMA).
-        weight (float): The weight of current_val; the weight of past_ewma is (1-weight).
+        current_val (float): Current value, bounded in [0, 360) if is_angle is true.
+        past_ewma (float): Past value (EWMA), bounded in [0, 360) if is_angle is true.
+        weight (float): The weight of current_val, bounded in [0, 1]; the weight of past_ewma is (1-weight).
         is_angle (bool): True when getting the field is an angle, false otherwise.
 
     Returns:

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -322,6 +322,12 @@ def bearingToHeadingDegrees(bearingDegrees):
     return (-bearingDegrees + 90) % 360
 
 
+def flipDirection(degrees):
+    '''Returns the reverse direction (flipped by 180 degrees) bounded in [0, 360).
+    '''
+    return (degrees + 180) % 360
+
+
 def vectorAverage(magnitudes, angles, weights=None):
     """Computes the weighted average of vectors using vector addition.
 

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -119,35 +119,6 @@ class TestUtilities(unittest.TestCase):
                                0,
                                places=3)
 
-    def test_boundIn0To360(self):
-        # integers
-        self.assertEqual(0, utils.boundIn0To360(0))
-        self.assertEqual(3, utils.boundIn0To360(3))
-        self.assertEqual(359, utils.boundIn0To360(359))
-        self.assertEqual(0, utils.boundIn0To360(360))
-        self.assertEqual(0, utils.boundIn0To360(-360))
-        self.assertEqual(0, utils.boundIn0To360(-23 * 360))
-        self.assertEqual(0, utils.boundIn0To360(23 * 360))
-
-        self.assertEqual(10, utils.boundIn0To360(360 + 10))
-        self.assertEqual(72, utils.boundIn0To360(23 * 360 + 72))
-
-        self.assertEqual(270, utils.boundIn0To360(-90))
-        self.assertEqual(350, utils.boundIn0To360(-370))
-        self.assertEqual(240, utils.boundIn0To360(-23 * 360 - 120))
-
-        # floats
-        self.assertAlmostEqual(0.0, utils.boundIn0To360(0.0), places=3)
-        self.assertAlmostEqual(3.2, utils.boundIn0To360(3.2), places=3)
-        self.assertAlmostEqual(359.0, utils.boundIn0To360(359), places=3)
-
-        self.assertAlmostEqual(10.0, utils.boundIn0To360(360 + 10.0), places=3)
-        self.assertAlmostEqual(72.0, utils.boundIn0To360(23 * 360.0 + 72), places=3)
-
-        self.assertAlmostEqual(270.0, utils.boundIn0To360(-90.0), places=3)
-        self.assertAlmostEqual(350.0, utils.boundIn0To360(-370), places=3)
-        self.assertAlmostEqual(240.0, utils.boundIn0To360(-23 * 360.0 - 120), places=3)
-
     def test_vectorAverage(self):
         # Basic tests
         magnitude, angle = utils.vectorAverage([1.0, 1.0], [1.0, -1.0])

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -119,6 +119,12 @@ class TestUtilities(unittest.TestCase):
                                0,
                                places=3)
 
+    def test_flipDirection(self):
+        self.assertEqual(0, utils.flipDirection(180))
+        self.assertEqual(180, utils.flipDirection(0))
+        self.assertEqual(0, utils.flipDirection(540))
+        self.assertEqual(180, utils.flipDirection(-360))
+
     def test_vectorAverage(self):
         # Basic tests
         magnitude, angle = utils.vectorAverage([1.0, 1.0], [1.0, -1.0])


### PR DESCRIPTION
Numerous updates related to angle bounding and conventions that arose during yesterday's dry land testing
1. Replace `boundIn0To360(num)` with `(num) % 360`
2. Bound the exponentially weighted moving average for angles in [0, 360)
3. Convert wind sensor direction conventions to our software's conventions: the wind sensors identify the direction wind is coming from (e.g., 180 is downwind) whereas our software expects the direction wind is going to (e.g., 0 is downwind)