### PR TITLE
handled invalid AIS coordinates

### DIFF
--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -176,6 +176,13 @@ class Sailbot:
         self.globalWindLastUpdate = time.time()
 
     def AISCallback(self, data):
+
+        for ship in data.ships:
+            if not utils.checkLatLonIsValid(latlon(ship.lat, ship.lon)):
+                data.ships.remove(ship)
+                rospy.logwarn_throttle(5, "Invalid co-ordinates for "
+                                       + "AIS Ship ID {}: ({}, {})".format(ship.ID, ship.lat, ship.lon))
+
         self.AISData = data
         self.AISLastUpdate = time.time()
 

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -176,15 +176,18 @@ class Sailbot:
         self.globalWindLastUpdate = time.time()
 
     def AISCallback(self, data):
+        # handle ships with invalid latlons
         filteredShips = []
-
+        invalidShips = []
         for ship in data.ships:
-            if utils.checkLatLonIsValid(latlon(ship.lat, ship.lon)):
+            if -90 < ship.lat < 90 and -180 < ship.lon < 180:
                 filteredShips.append(ship)
-
             else:
-                rospy.logwarn_throttle(5, "Invalid co-ordinates for "
-                                       + "AIS Ship ID {}: ({}, {})".format(ship.ID, ship.lat, ship.lon))
+                invalidShips.append(ship)
+        if invalidShips:
+            warn_msg = "Invalid coordinates for AIS Ships" + \
+                ''.join(['\n\tID {}: ({}, {})'.format(ship.ID, ship.lat, ship.lon) for ship in invalidShips])
+            rospy.logwarn_throttle(5, warn_msg)
 
         data.ships = filteredShips
         self.AISData = data

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -189,8 +189,7 @@ class Sailbot:
                 ''.join(['\n\tID {}: ({}, {})'.format(ship.ID, ship.lat, ship.lon) for ship in invalidShips])
             rospy.logwarn_throttle(5, warn_msg)
 
-        data.ships = filteredShips
-        self.AISData = data
+        self.AISData = AISMsg(ships=filteredShips)
         self.AISLastUpdate = time.time()
 
     def globalPathCallback(self, data):

--- a/python/Sailbot.py
+++ b/python/Sailbot.py
@@ -176,13 +176,17 @@ class Sailbot:
         self.globalWindLastUpdate = time.time()
 
     def AISCallback(self, data):
+        filteredShips = []
 
         for ship in data.ships:
-            if not utils.checkLatLonIsValid(latlon(ship.lat, ship.lon)):
-                data.ships.remove(ship)
+            if utils.checkLatLonIsValid(latlon(ship.lat, ship.lon)):
+                filteredShips.append(ship)
+
+            else:
                 rospy.logwarn_throttle(5, "Invalid co-ordinates for "
                                        + "AIS Ship ID {}: ({}, {})".format(ship.ID, ship.lat, ship.lon))
 
+        data.ships = filteredShips
         self.AISData = data
         self.AISLastUpdate = time.time()
 

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -150,18 +150,6 @@ def XYToLatlon(xy, referenceLatlon):
     return latlon(destination.latitude, destination.longitude)
 
 
-def checkLatLonIsValid(latlon):
-    '''Determine if the latlon is valid
-
-    Args:
-        latlon: a latlon to check for validity
-
-    Returns:
-        True if the latitude and longitude are within [-90, 90] and [-180, 180] respectively, and false otherwise.
-    '''
-    return latlon.lat > -90 and latlon.lat < 90 and latlon.lon > -180 and latlon.lon < 180
-
-
 def timeLimitExceeded(lastTimePathCreated, speedup):
     '''Checks the time since last path was created has been too long. Ensures the boat is
     not stuck to a poor, stagnant path

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -157,7 +157,7 @@ def checkLatLonIsValid(latlon):
         latlon: a latlon to check for validity
 
     Returns:
-        True if the latitude and longditude are within [-90, 90] and [-180, 180] respectively, and false otherwise.
+        True if the latitude and longitude are within [-90, 90] and [-180, 180] respectively, and false otherwise.
     '''
     return latlon.lat > -90 and latlon.lat < 90 and latlon.lon > -180 and latlon.lon < 180
 

--- a/python/utilities.py
+++ b/python/utilities.py
@@ -150,6 +150,18 @@ def XYToLatlon(xy, referenceLatlon):
     return latlon(destination.latitude, destination.longitude)
 
 
+def checkLatLonIsValid(latlon):
+    '''Determine if the latlon is valid
+
+    Args:
+        latlon: a latlon to check for validity
+
+    Returns:
+        True if the latitude and longditude are within [-90, 90] and [-180, 180] respectively, and false otherwise.
+    '''
+    return latlon.lat > -90 and latlon.lat < 90 and latlon.lon > -180 and latlon.lon < 180
+
+
 def timeLimitExceeded(lastTimePathCreated, speedup):
     '''Checks the time since last path was created has been too long. Ensures the boat is
     not stuck to a poor, stagnant path


### PR DESCRIPTION
`AISCallback()` in Sailbot.py now removes any AIS boats with latitude outside [-90, 90] or longitude outside [-180, 180].

- Imade a utilities function `checkLatLonIsValid()` to check if a latlon is valid. Is this useful or should I delete this function and just check for validity in `AISCallback()`?
- I wanted to use the `List.remove()` function but then the loop seemed to run the incorrect number of times if I removed items from the list of ships during the loop. I don't really like that I needed to create a whole new list of AIS boats though, as this seems inefficient. Is there a better way I should do this? For example I could `pop()` the element at `[(loop index) - (number of boats removed so far)]
- Should I make it so that we can easily toggle between bounding invalid coordinates to valid equivalents vs deleting AIS boats with invalid coordinates?