### PR TITLE
Increment global path index to first unreached waypoint on new path

### DIFF
--- a/python/main_loop.py
+++ b/python/main_loop.py
@@ -169,10 +169,6 @@ if __name__ == '__main__':
             if localPathUpdateForced:
                 localPathUpdateForced = False
 
-            # Reset sailbot newGlobalPathReceived boolean
-            if newGlobalPathReceived:
-                sailbot.newGlobalPathReceived = False
-
             # Reset sbot.goalWasInvalid boolean
             if sbot.goalWasInvalid:
                 sbot.goalWasInvalid = False
@@ -181,6 +177,18 @@ if __name__ == '__main__':
             if isGlobalWaypointReached:
                 rospy.loginfo("Global waypoint reached")
                 sailbot.globalPathIndex += 1
+                nextGlobalWaypoint = sailbot.globalPath[sailbot.globalPathIndex]
+                previousGlobalWaypoint = sailbot.globalPath[sailbot.globalPathIndex - 1]
+
+            # Reset sailbot newGlobalPathReceived boolean
+            if newGlobalPathReceived:
+                sailbot.newGlobalPathReceived = False
+
+                while localPath.waypointReached(state.position, previousGlobalWaypoint, nextGlobalWaypoint, True):
+                    rospy.logwarn('Already reached next global waypoint, incrementing global path index')
+                    sailbot.globalPathIndex += 1
+                    nextGlobalWaypoint = sailbot.globalPath[sailbot.globalPathIndex]
+                    previousGlobalWaypoint = sailbot.globalPath[sailbot.globalPathIndex - 1]
 
             # Update local path
             localPath, lastTimePathCreated = createNewLocalPath(


### PR DESCRIPTION
This handles the case where we lose power in the middle of a global path. On startup local pathfinding assumes that the next global waypoint is index 1 of the global path, so I decided to increment the global path index to the first unreached waypoint whenever a new global path is published